### PR TITLE
revert scrollToTop change

### DIFF
--- a/components/d2l-sequences-content-file-download.html
+++ b/components/d2l-sequences-content-file-download.html
@@ -112,7 +112,6 @@
 			}
 			connectedCallback() {
 				super.connectedCallback();
-				window.top.scrollTo(0,0);
 				this._language = window.document.getElementsByTagName('html')[0]
 					.getAttribute('lang');
 			}

--- a/components/d2l-sequences-content-file-html.html
+++ b/components/d2l-sequences-content-file-html.html
@@ -25,26 +25,8 @@
 					title: {
 						type: String,
 						computed: '_getTitle(entity)'
-					},
-					_loadListener: {
-						type: Object
 					}
 				}
-			}
-
-			connectedCallback() {
-				super.connectedCallback();
-				this._loadListener = this.$.content.addEventListener('load', this._scrollToTop.bind(this));
-			}
-
-			disconnectedCallback() {
-				super.disconnectedCallback();
-				this.$.content.removeEventListener('load', this._loadListener);
-				this._loadListener = null;
-			}
-
-			_scrollToTop() {
-				window.top.scrollTo(0,0);
 			}
 
 			_getFileLocation(entity) {

--- a/components/d2l-sequences-content-link-mixed.html
+++ b/components/d2l-sequences-content-link-mixed.html
@@ -76,7 +76,6 @@
 			}
 			connectedCallback() {
 				super.connectedCallback();
-				window.top.scrollTo(0,0);
 				this._language = window.document.getElementsByTagName('html')[0]
 					.getAttribute('lang');
 			}

--- a/components/d2l-sequences-content-link-scorm.html
+++ b/components/d2l-sequences-content-link-scorm.html
@@ -84,7 +84,6 @@
 			}
 			connectedCallback() {
 				super.connectedCallback();
-				window.top.scrollTo(0,0);
 				this._language = window.document.getElementsByTagName('html')[0]
 					.getAttribute('lang');
 			}

--- a/components/d2l-sequences-content-link.html
+++ b/components/d2l-sequences-content-link.html
@@ -37,29 +37,11 @@
 					_linkLocation: {
 						type: String,
 						computed: '_getLinkLocation(entity)'
-					},
-					_loadListener: {
-						type: Object
 					}
 				}
 			}
 			static get observers() {
 				return ['_render(entity)']
-			}
-
-			connectedCallback() {
-				super.connectedCallback();
-				this._loadListener = this.$.content.addEventListener('load', this._scrollToTop.bind(this));
-			}
-
-			disconnectedCallback() {
-				super.disconnectedCallback();
-				this.$.content.removeEventListener('load', this._loadListener);
-				this._loadListener = null;
-			}
-
-			_scrollToTop() {
-				window.top.scrollTo(0,0);
 			}
 
 			_getLinkLocation(entity) {

--- a/components/d2l-sequences-content-unknown.html
+++ b/components/d2l-sequences-content-unknown.html
@@ -16,7 +16,6 @@
 			}
 			connectedCallback() {
 				super.connectedCallback();
-				window.top.scrollTo(0,0);
 				this._language = window.document.getElementsByTagName('html')[0]
 					.getAttribute('lang');
 			}


### PR DESCRIPTION
The scrollToTop method is causing cross-origin errors because you're not supposed to have access to window.top from within an iframe. That's my understanding of it anyway.

https://stackoverflow.com/questions/4724904/how-to-change-style-of-iframe-content-cross-domain

So I'll revert the change for now.