### PR TITLE
Spinner covers iframe when token changes but href stays the same

### DIFF
--- a/components/d2l-sequences-content-link-onedrive.html
+++ b/components/d2l-sequences-content-link-onedrive.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../../d2l-content-icons/d2l-content-icons.html">
+<link rel="import" href="../../d2l-content-icons/d2l-open-one-drive-icon.html">
 <link rel="import" href="../../d2l-button/d2l-button.html">
 <link rel="import" href="d2l-sequences-content-link.html">
 <link rel="import" href="../mixins/d2l-sequences-automatic-completion-tracking-mixin.html">

--- a/components/d2l-sequences-content-link.html
+++ b/components/d2l-sequences-content-link.html
@@ -40,6 +40,9 @@
 						notify: true,
 						observer: '_scrollToTop'
 					},
+					previousHref: {
+						type: String
+					},
 					_linkLocation: {
 						type: String,
 						computed: '_getLinkLocation(entity)'
@@ -65,6 +68,15 @@
 
 			/* eslint no-unused-vars: 0 */
 			_render(entity) {
+				// iframe won't reload if the href doesn't change
+				// so this prevents the spinner from covering it
+				// forever
+				if (this.href === this.previousHref) {
+					return;
+				}
+
+				this.previousHref = this.href;
+
 				const content = this.shadowRoot.getElementById('content');
 				const spinner = this.shadowRoot.getElementById('spinner');
 


### PR DESCRIPTION
Fix spinner covering iframe when same href passed in
Fix lint issue of not including correct html import for one drive