### PR TITLE
Fix embed link location getter

### DIFF
--- a/components/d2l-sequences-content-link.html
+++ b/components/d2l-sequences-content-link.html
@@ -60,7 +60,7 @@
 				try {
 					const linkActivity = entity.getSubEntityByClass(D2LSequencesContentLink.contentClass);
 					// if embed link exists, use that link
-					const embedLink = linkActivity.getLinkByRel('embed');
+					const embedLink = linkActivity.getLinkByClass('embed');
 					if (embedLink !== undefined) {
 						return embedLink.href;
 					} else {


### PR DESCRIPTION
Instead of calling getLinkByRel we should be calling getLinkByClass to get the embed link.