### PR TITLE
switch our spinner hider to use visibility hidden vs display none so

### DIFF
--- a/components/d2l-sequences-content-link.html
+++ b/components/d2l-sequences-content-link.html
@@ -10,7 +10,7 @@
 				overflow: hidden;
 			}
 			.hide {
-				display: none;
+				visibility: hidden;
 			}
 			d2l-loading-spinner {
 				position: fixed;
@@ -92,11 +92,8 @@
 				spinner.classList.remove('hide');
 
 				content.onload = function() {
-					// give the LMS some time to jiggle and shake...
-					setTimeout(() => {
-						content.classList.remove('hide');
-						spinner.classList.add('hide');
-					}, 200);
+					content.classList.remove('hide');
+					spinner.classList.add('hide');
 				};
 			}
 		}


### PR DESCRIPTION
that the internal class initializers don't break when getting bounding
rectangles

navigated around, and removing the timeout doesn't seem to cause a problem.