### PR TITLE
Fix incorrect download file size

### DIFF
--- a/components/d2l-sequences-content-file-download.html
+++ b/components/d2l-sequences-content-file-download.html
@@ -118,7 +118,7 @@
 			}
 
 			_setRawFileSize() {
-				if(!this._fileLocation) {
+				if (!this._fileLocation) {
 					return;
 				}
 

--- a/components/d2l-sequences-content-file-download.html
+++ b/components/d2l-sequences-content-file-download.html
@@ -118,6 +118,10 @@
 			}
 
 			_setRawFileSize() {
+				if(!this._fileLocation) {
+					return;
+				}
+
 				fetch(this._fileLocation, {
 					method: 'HEAD',
 					headers: new Headers({


### PR DESCRIPTION
The issue here is that when you call `fetch` with an empty string, it uses the current browser location and fetches that. When our page loads, polymer was passing an empty string while it was loading the entity and then the real location after. Both promises would occur and whichever finished last would be displayed. Now we just don't run `fetch` unless we have a value.