### PR TITLE
Send click-back event when Done button clicked

### DIFF
--- a/components/d2l-sequences-content-eol-main.html
+++ b/components/d2l-sequences-content-eol-main.html
@@ -36,9 +36,7 @@
 					[[localize('activitiesFinishedGreatJob')]]
 				</p>
 				<d2l-button primary on-click="_onClickBack">
-					<label>
-						[[localize('imDone')]]
-					</label>
+					[[localize('imDone')]]
 				</d2l-button>
 			</template>
  			<template is="dom-if" if="[[hasMissed]]">
@@ -54,14 +52,10 @@
 						[[localize('noNeedToFinish', 'count', missedCount)]]
 					</p>
 					<d2l-button on-click="_setShowMissed">
-						<label>
-							[[localize('showMissed')]]
-						</label>
+						[[localize('showMissed')]]
 					</d2l-button>
 					<d2l-button primary on-click="_onClickBack">
-						<label>
-							[[localize('imDone')]]
-						</label>
+						[[localize('imDone')]]
 					</d2l-button>
 				</template>
 				<template is="dom-if" if="[[showMissed]]">

--- a/components/d2l-sequences-content-eol-main.html
+++ b/components/d2l-sequences-content-eol-main.html
@@ -140,19 +140,12 @@
 				return entity.entities.length;
 			}
 			_onClickBack() {
-				if (!this.returnUrl) {
-					return;
-				}
-				if (window.parent === window) {
-					window.location.href = this.returnUrl;
-					return;
-				}
+				const event = new CustomEvent('click-back', {
+					composed: true,
+					bubbles: true
+				});
 
-				// If we're in an iframe we need to post a message to do the navigation for us
-				window.parent.postMessage(JSON.stringify({
-					eventType: 'd2l-sequence-viewer-return',
-					returnUrl: this.returnUrl
-				}), '*');
+				this.dispatchEvent(event);
 			}
 			_setShowMissed() {
 				this.showMissed = true;

--- a/components/d2l-sequences-content-eol-main.html
+++ b/components/d2l-sequences-content-eol-main.html
@@ -5,6 +5,8 @@
 <link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-end-of-lesson-image.html">
+<link rel="import" href="../mixins/d2l-sequences-return-mixin.html">
+
  <dom-module id="d2l-sequences-content-eol-main">
 	<template>
 		<style>
@@ -65,8 +67,7 @@
 				<template is="dom-if" if="[[showMissed]]">
 					<d2l-sequences-content-eol-missed
 						href="{{href}}"
-						token="[[token]]"
-						return-url="[[returnUrl]]">
+						token="[[token]]">
 					</d2l-sequences-content-eol-missed>
 				</template>
 			</template>	
@@ -76,12 +77,10 @@
 		/*
 			@extends D2L.PolymerBehaviors.Sequences.LocalizeBehavior
 		*/
-		class D2LSequencesContentEoLMain extends Polymer.mixinBehaviors([
+		class D2LSequencesContentEoLMain extends D2L.Polymer.Mixins.Sequences.ReturnMixin([
 			D2L.PolymerBehaviors.Siren.EntityBehavior,
 			D2L.PolymerBehaviors.Sequences.LocalizeBehavior
-		],
-		Polymer.Element
-		) {
+		]) {
 			static get is() {
 				return 'd2l-sequences-content-eol-main';
 			}
@@ -95,10 +94,6 @@
 					},
 					token: {
 						type: String
-					},
-					returnUrl: {
-						type: String,
-						value: false
 					},
 					missedCount: {
 						type: Number,
@@ -138,14 +133,6 @@
 			_getMissedCount(entity) {
 				if (!entity) return 0;
 				return entity.entities.length;
-			}
-			_onClickBack() {
-				const event = new CustomEvent('click-back', {
-					composed: true,
-					bubbles: true
-				});
-
-				this.dispatchEvent(event);
 			}
 			_setShowMissed() {
 				this.showMissed = true;

--- a/components/d2l-sequences-content-eol-missed.html
+++ b/components/d2l-sequences-content-eol-missed.html
@@ -3,6 +3,8 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
 <link rel="import" href="../localize-behavior.html">
+<link rel="import" href="../mixins/d2l-sequences-return-mixin.html">
+
  <dom-module id="d2l-sequences-content-eol-missed">
 	<template>
 		<style>
@@ -54,12 +56,10 @@
 		/*
 			@extends D2L.PolymerBehaviors.Sequences.LocalizeBehavior
 		*/
-		class D2LSequencesContentEoLMissed extends Polymer.mixinBehaviors([
+		class D2LSequencesContentEoLMissed extends D2L.Polymer.Mixins.Sequences.ReturnMixin([
 			D2L.PolymerBehaviors.Siren.EntityBehavior,
 			D2L.PolymerBehaviors.Sequences.LocalizeBehavior
-		],
-		Polymer.Element
-		) {
+		]) {
 			static get is() {
 				return 'd2l-sequences-content-eol-missed';
 			}
@@ -73,10 +73,6 @@
 					},
 					token: {
 						type: String
-					},
-					returnUrl: {
-						type: String,
-						value: false
 					},
 					subEntities: {
 						type: Object,
@@ -94,21 +90,6 @@
 					return [];
 				}
 				return entity.entities;
-			}
-			_onClickBack() {
-				if (!this.returnUrl) {
-					return;
-				}
-				if (window.parent === window) {
-					window.location.href = this.returnUrl;
-					return;
-				}
-
-				// If we're in an iframe we need to post a message to do the navigation for us
-				window.parent.postMessage(JSON.stringify({
-					eventType: 'd2l-sequence-viewer-return',
-					returnUrl: this.returnUrl
-				}), '*');
 			}
 		}
 		customElements.define(D2LSequencesContentEoLMissed.is, D2LSequencesContentEoLMissed);

--- a/components/d2l-sequences-content-eol-missed.html
+++ b/components/d2l-sequences-content-eol-missed.html
@@ -46,9 +46,7 @@
 				</template>
 			</ol>
 			<d2l-button primary on-click="_onClickBack">
-				<label>
-					[[localize('imDone')]]
-				</label>
+				[[localize('imDone')]]
 			</d2l-button>
 		</div>
 	</template>

--- a/mixins/d2l-sequences-return-mixin.html
+++ b/mixins/d2l-sequences-return-mixin.html
@@ -3,7 +3,7 @@
     	function ReturnMixin(classes) {
     		return class extends Polymer.mixinBehaviors(classes, Polymer.Element) {
     			_onClickBack() {
-    				const event = new CustomEvent('click-back', {
+				const event = new CustomEvent('sequences-return-mixin-click-back', {
     					composed: true,
     					bubbles: true
     				});

--- a/mixins/d2l-sequences-return-mixin.html
+++ b/mixins/d2l-sequences-return-mixin.html
@@ -1,0 +1,22 @@
+<script>
+    (function () {
+        function ReturnMixin(classes) {
+            return class extends Polymer.mixinBehaviors(classes, Polymer.Element) {
+                _onClickBack() {
+                    const event = new CustomEvent('click-back', {
+                        composed: true,
+                        bubbles: true
+                    });
+
+                    this.dispatchEvent(event);
+                }
+            }
+        }
+
+        window.D2L = window.D2L || {};
+        window.D2L.Polymer = window.D2L.Polymer || {};
+        window.D2L.Polymer.Mixins = window.D2L.Polymer.Mixins || {};
+        window.D2L.Polymer.Mixins.Sequences = window.D2L.Polymer.Mixins.Sequences || {};
+        window.D2L.Polymer.Mixins.Sequences.ReturnMixin = ReturnMixin;
+    })();
+</script>

--- a/mixins/d2l-sequences-return-mixin.html
+++ b/mixins/d2l-sequences-return-mixin.html
@@ -1,22 +1,22 @@
 <script>
-    (function () {
-        function ReturnMixin(classes) {
-            return class extends Polymer.mixinBehaviors(classes, Polymer.Element) {
-                _onClickBack() {
-                    const event = new CustomEvent('click-back', {
-                        composed: true,
-                        bubbles: true
-                    });
+    (function() {
+    	function ReturnMixin(classes) {
+    		return class extends Polymer.mixinBehaviors(classes, Polymer.Element) {
+    			_onClickBack() {
+    				const event = new CustomEvent('click-back', {
+    					composed: true,
+    					bubbles: true
+    				});
 
-                    this.dispatchEvent(event);
-                }
-            }
-        }
+    				this.dispatchEvent(event);
+    			}
+    		};
+    	}
 
-        window.D2L = window.D2L || {};
-        window.D2L.Polymer = window.D2L.Polymer || {};
-        window.D2L.Polymer.Mixins = window.D2L.Polymer.Mixins || {};
-        window.D2L.Polymer.Mixins.Sequences = window.D2L.Polymer.Mixins.Sequences || {};
-        window.D2L.Polymer.Mixins.Sequences.ReturnMixin = ReturnMixin;
+    	window.D2L = window.D2L || {};
+    	window.D2L.Polymer = window.D2L.Polymer || {};
+    	window.D2L.Polymer.Mixins = window.D2L.Polymer.Mixins || {};
+    	window.D2L.Polymer.Mixins.Sequences = window.D2L.Polymer.Mixins.Sequences || {};
+    	window.D2L.Polymer.Mixins.Sequences.ReturnMixin = ReturnMixin;
     })();
 </script>


### PR DESCRIPTION
Part 2

We'll send a `back-click` event from the EoL `I'm Done` button to signal the viewer to navigate to the `returnUrl`. We don't have access to it on the EoL page anymore since everything goes through the router and the router only passes href and token. 