### PR TITLE
Add new property error, show uknown page when error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
 		"D2LSequencesContentLinkOnedrive": false,
 		"D2LSequencesContentFileDownload": false,
 		"D2LSequencesContentEoLMain": false,
-		"D2LSequencesContentModule": false
+		"D2LSequencesContentModule": false,
+		"D2LSequencesContentError": false
 	}
 }

--- a/components/d2l-sequences-content-error.html
+++ b/components/d2l-sequences-content-error.html
@@ -1,0 +1,16 @@
+<link rel="import" href="../polymer/polymer.html">
+<dom-module id="d2l-sequences-content-error">
+	<template>
+		<style>
+		</style>
+		[[localize('cannotBeRendered')]]
+	</template>
+	<script>
+		class D2LSequencesContentError extends Polymer.Element {
+			static get is() {
+				return 'd2l-sequences-content-error';
+			}
+		}
+		customElements.define(D2LSequencesContentError.is, D2LSequencesContentError);
+	</script>
+</dom-module>

--- a/components/d2l-sequences-content-error.html
+++ b/components/d2l-sequences-content-error.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../localize-behavior.html">
 <dom-module id="d2l-sequences-content-error">
 	<template>
 		<style>

--- a/components/d2l-sequences-content-error.html
+++ b/components/d2l-sequences-content-error.html
@@ -1,4 +1,3 @@
-<link rel="import" href="../bower_components/polymer/polymer.html">
 <dom-module id="d2l-sequences-content-error">
 	<template>
 		<style>
@@ -6,7 +5,11 @@
 		[[localize('cannotBeRendered')]]
 	</template>
 	<script>
-		class D2LSequencesContentError extends Polymer.Element {
+		class D2LSequencesContentError extends Polymer.mixinBehaviors([
+			D2L.PolymerBehaviors.Sequences.LocalizeBehavior
+		],
+		Polymer.Element
+		) {
 			static get is() {
 				return 'd2l-sequences-content-error';
 			}

--- a/components/d2l-sequences-content-error.html
+++ b/components/d2l-sequences-content-error.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../bower_components/polymer/polymer.html">
 <dom-module id="d2l-sequences-content-error">
 	<template>
 		<style>

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -57,13 +57,13 @@
 						this._debouncer,
 						Polymer.Async.timeOut.after(20),
 						() => {
-							const entityType = error 
-								? D2LSequencesContentError.is 
+							const entityType = error
+								? D2LSequencesContentError.is
 								: getEntityType(entity);
 
 							const replaceContentElement = (entity &&
 								(!this._contentElement || this._contentElement.href !== this.href)
-								) || error;
+							) || error;
 
 							if (replaceContentElement) {
 								this.error = false;

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -1,6 +1,5 @@
-<link rel="import" href="../components//d2l-sequences-content-error.html">
 <link rel="import" href="../../polymer/lib/utils/debounce.html">
-
+<link rel="import" href="../components//d2l-sequences-content-error.html">
 <script>
 	(function() {
 		function RouterMixin(getEntityType) {

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -26,8 +26,7 @@
 							type: Function
 						},
 						error: {
-							type: Boolean,
-							value: false
+							type: Boolean
 						}
 					};
 				}
@@ -42,9 +41,7 @@
 						this.href = detail.href;
 					});
 					this._D2LErrorListener = window.addEventListener('message', (event) => {
-						if (event.data.type === 'd2l-error') {
-							this.error = true;
-						}
+						this.error = event.data.type === 'd2l-error';
 					});
 				}
 
@@ -60,15 +57,15 @@
 						this._debouncer,
 						Polymer.Async.timeOut.after(20),
 						() => {
-							let entityType = getEntityType(entity);
-							if (error) {
-								entityType = D2LSequencesContentError.is;
-							}
-							if (
-								(entity &&
+							const entityType = error 
+								? D2LSequencesContentError.is 
+								: getEntityType(entity);
+
+							const replaceContentElement = (entity &&
 								(!this._contentElement || this._contentElement.href !== this.href)
-								) || error
-							) {
+								) || error;
+
+							if (replaceContentElement) {
 								this.error = false;
 								const nodeTemplate = Polymer.DomModule.import(entityType, 'template');
 								const contentElement = document.createElement(entityType);

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/lib/utils/debounce.html">
+<link rel="import" href="../components//d2l-sequences-content-unknown.html">
 <script>
 	(function() {
 		function RouterMixin(getEntityType) {
@@ -23,12 +24,16 @@
 						},
 						_hrefUpdated: {
 							type: Function
+						},
+						error: {
+							type: Boolean,
+							value: false
 						}
 					};
 				}
 
 				static get observers() {
-					return ['_render(entity)'];
+					return ['_render(entity, error)'];
 				}
 
 				connectedCallback() {
@@ -36,23 +41,35 @@
 					this._hrefUpdated = this.addEventListener('hrefUpdated', ({detail}) => {
 						this.href = detail.href;
 					});
+					this._D2lErrorListener = window.addEventListener('message', (event) => {
+						if (event.data.type === 'd2l-error') {
+							this.error = true;
+						}
+					});
 				}
 
 				disconnectedCallback() {
 					super.disconnectedCallback();
 					this.removeEventListener('hrefUpdated', this._hrefUpdated);
+					this.removeEventListener('message', this._D2lErrorListener);
 				}
 
-				_render(entity) {
+				_render(entity, error) {
 					getEntityType = getEntityType.bind(this);
 					this._debouncer = Polymer.Debouncer.debounce(
 						this._debouncer,
 						Polymer.Async.timeOut.after(20),
 						() => {
-							const entityType = getEntityType(entity);
-							if (entity &&
+							let entityType = getEntityType(entity);
+							if (error) {
+								entityType = D2LSequencesContentUnknown.is;
+							}
+							if (
+								(entity &&
 								(!this._contentElement || this._contentElement.href !== this.href)
+								) || error
 							) {
+								this.error = false;
 								const nodeTemplate = Polymer.DomModule.import(entityType, 'template');
 								const contentElement = document.createElement(entityType);
 								contentElement.appendChild(this._stampTemplate(nodeTemplate));

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -41,7 +41,7 @@
 					this._hrefUpdated = this.addEventListener('hrefUpdated', ({detail}) => {
 						this.href = detail.href;
 					});
-					this._D2lErrorListener = window.addEventListener('message', (event) => {
+					this._D2LErrorListener = window.addEventListener('message', (event) => {
 						if (event.data.type === 'd2l-error') {
 							this.error = true;
 						}
@@ -51,7 +51,7 @@
 				disconnectedCallback() {
 					super.disconnectedCallback();
 					this.removeEventListener('hrefUpdated', this._hrefUpdated);
-					this.removeEventListener('message', this._D2lErrorListener);
+					this.removeEventListener('message', this._D2LErrorListener);
 				}
 
 				_render(entity, error) {

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -1,5 +1,6 @@
+<link rel="import" href="../components//d2l-sequences-content-error.html">
 <link rel="import" href="../../polymer/lib/utils/debounce.html">
-<link rel="import" href="../components//d2l-sequences-content-unknown.html">
+
 <script>
 	(function() {
 		function RouterMixin(getEntityType) {
@@ -62,7 +63,7 @@
 						() => {
 							let entityType = getEntityType(entity);
 							if (error) {
-								entityType = D2LSequencesContentUnknown.is;
+								entityType = D2LSequencesContentError.is;
 							}
 							if (
 								(entity &&

--- a/mixins/d2l-sequences-router-mixin.html
+++ b/mixins/d2l-sequences-router-mixin.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../polymer/lib/utils/debounce.html">
-<link rel="import" href="../components//d2l-sequences-content-error.html">
+<link rel="import" href="../components/d2l-sequences-content-error.html">
 <script>
 	(function() {
 		function RouterMixin(getEntityType) {


### PR DESCRIPTION
Add a new property 'error' to the element and use the render function to observer changes. When error occurs, we replace the current element in the page with a new component,  `D2LSequenceContentError`. If any additional dialogs are open, they will be closed.

We can use this new element to customize the contents of the page based on the the type of error, etc. 

Important note: If this change is merged, the LMS error page will no longer be shown/available to the user. 

Related, LMS-side PRs: 

https://git.dev.d2l/projects/CORE/repos/platformtools/pull-requests/2820/overview
https://git.dev.d2l/projects/CORE/repos/le/pull-requests/13645/overview