### PR TITLE
Use proper ES6 module imports in tests

### DIFF
--- a/components/d2l-sequences-module-name.js
+++ b/components/d2l-sequences-module-name.js
@@ -6,7 +6,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 /*
 	@demo demos/index.html
  */
-class D2LSequencesModuleName extends mixinBehaviors([
+export class D2LSequencesModuleName extends mixinBehaviors([
 	D2L.PolymerBehaviors.Siren.EntityBehavior
 ], PolymerElement) {
 	static get template() {

--- a/components/d2l-sequences-topic-name.js
+++ b/components/d2l-sequences-topic-name.js
@@ -6,7 +6,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 /*
 	@demo demos/index.html
  */
-class D2LSequencesTopicName extends mixinBehaviors([
+export class D2LSequencesTopicName extends mixinBehaviors([
 	D2L.PolymerBehaviors.Siren.EntityBehavior
 ], PolymerElement) {
 	static get template() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1483,10 +1483,20 @@
       "requires": {
         "@polymer/iron-media-query": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#62489aaf9e93d66a54e5838ad97f616951030c2f"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+      },
+      "dependencies": {
+        "d2l-typography": {
+          "version": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+          "from": "github:BrightspaceUI/typography#semver:^7",
+          "requires": {
+            "@polymer/polymer": "^3.0.0",
+            "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
+          }
+        }
       }
     },
     "d2l-colors": {
@@ -1516,7 +1526,7 @@
       "requires": {
         "@polymer/iron-iconset-svg": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
       }
     },
     "d2l-intl": {
@@ -1529,8 +1539,25 @@
       "from": "github:BrightspaceUI/link#semver:^5",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
+      },
+      "dependencies": {
+        "d2l-colors": {
+          "version": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
+          "from": "github:BrightspaceUI/colors#semver:^4",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "d2l-polymer-behaviors": {
+          "version": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
+          "from": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+          "requires": {
+            "@polymer/polymer": "^3.0.0",
+            "fastdom": "^1.0.8"
+          }
+        }
       }
     },
     "d2l-loading-spinner": {
@@ -1538,7 +1565,16 @@
       "from": "github:BrightspaceUI/loading-spinner#semver:^7",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
+      },
+      "dependencies": {
+        "d2l-colors": {
+          "version": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
+          "from": "github:BrightspaceUI/colors#semver:^4",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
       }
     },
     "d2l-localize-behavior": {
@@ -1555,16 +1591,80 @@
       "from": "github:BrightspaceUI/navigation#semver:^3",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
-        "d2l-icons": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
-        "d2l-link": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#72a50c6326da620d654f6ed1f8e289abb80d2503",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
-        "d2l-typography": "github:BrightspaceUI/typography#62489aaf9e93d66a54e5838ad97f616951030c2f",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-link": "github:BrightspaceUI/link#semver:^5",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fastdom": "^1.0.8",
         "resize-observer-polyfill": "^1.5.0"
+      },
+      "dependencies": {
+        "d2l-button": {
+          "version": "github:BrightspaceUI/button#67be142ac746ea52bf8b5e0c8c46dbd53fc0cc0d",
+          "from": "github:BrightspaceUI/button#semver:^5",
+          "requires": {
+            "@polymer/iron-media-query": "^3.0.0-pre.18",
+            "@polymer/polymer": "^3.0.0",
+            "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+            "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+            "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+            "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+          }
+        },
+        "d2l-colors": {
+          "version": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
+          "from": "github:BrightspaceUI/colors#semver:^4",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "d2l-icons": {
+          "version": "github:BrightspaceUI/icons#14d5205c725e6a23af91ca520574203f3bd1ef90",
+          "from": "github:BrightspaceUI/icons#semver:^6",
+          "requires": {
+            "@polymer/iron-iconset-svg": "^3.0.0",
+            "@polymer/polymer": "^3.0.0",
+            "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
+          }
+        },
+        "d2l-link": {
+          "version": "github:BrightspaceUI/link#0a11feef8cc0d75294f10a99f53cac36fe948584",
+          "from": "github:BrightspaceUI/link#semver:^5",
+          "requires": {
+            "@polymer/polymer": "^3.0.0",
+            "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+            "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2"
+          }
+        },
+        "d2l-localize-behavior": {
+          "version": "github:BrightspaceUI/localize-behavior#f784a06a7a9e334877ee0babfe614c19f7d10732",
+          "from": "github:BrightspaceUI/localize-behavior#semver:^2",
+          "requires": {
+            "@polymer/app-localize-behavior": "^3.0.0-pre.18",
+            "@polymer/polymer": "^3.0.0",
+            "d2l-intl": "^2.0.0"
+          }
+        },
+        "d2l-polymer-behaviors": {
+          "version": "github:Brightspace/d2l-polymer-behaviors-ui#ced40c46cbaa2710862c82e03ff373660b8223d9",
+          "from": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+          "requires": {
+            "@polymer/polymer": "^3.0.0",
+            "fastdom": "^1.0.8"
+          }
+        },
+        "d2l-typography": {
+          "version": "github:BrightspaceUI/typography#b990d1d3c14671403b0684a2dd87413ac3b7d4a7",
+          "from": "github:BrightspaceUI/typography#semver:^7",
+          "requires": {
+            "@polymer/polymer": "^3.0.0",
+            "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
+          }
+        }
       }
     },
     "d2l-offscreen": {
@@ -1586,7 +1686,7 @@
       "version": "github:Brightspace/polymer-siren-behaviors#1b2a70d9f6a04dc674a627b1ca4f51a8ca7a7796",
       "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "requires": {
-        "d2l-fetch": "github:Brightspace/d2l-fetch#4b826328c8db9466b66f8f84797f79d3dbd8b07e",
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "fastdom": "^1.0.8",
         "siren-parser": "^8.0.0"
       }
@@ -1596,7 +1696,16 @@
       "from": "github:BrightspaceUI/typography#semver:^7",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4"
+      },
+      "dependencies": {
+        "d2l-colors": {
+          "version": "github:BrightspaceUI/colors#6a1c414d6f3685e3c286aff4147ede037bdbb693",
+          "from": "github:BrightspaceUI/colors#semver:^4",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
       }
     },
     "debug": {
@@ -2562,7 +2671,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2583,12 +2693,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2603,17 +2715,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2730,7 +2845,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2742,6 +2858,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2756,6 +2873,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2763,12 +2881,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2787,6 +2907,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2867,7 +2988,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2879,6 +3001,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2964,7 +3087,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3000,6 +3124,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3019,6 +3144,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3062,12 +3188,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3462,9 +3590,9 @@
       }
     },
     "iframe-resizer": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-3.6.4.tgz",
-      "integrity": "sha512-cdEz9M7JK2vxwwcGfYs2NT/CGqdZ9YnEhNV81s7/gAcQmkRx41lOtQYoVVdTv680ZibCrG41kFOpnrHC4S30Pw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-3.6.5.tgz",
+      "integrity": "sha512-LmwYVNrrKIfVKqwO8dfSlOu5wggnOmr9OwvR1r6lyv33cBqyi3F+Lp5z3mg2wxIHAwf9cxKqtQkvgzkcywwkeg=="
     },
     "ifrau": {
       "version": "0.21.3",
@@ -9551,7 +9679,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10016,7 +10145,8 @@
               "version": "5.1.1",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
               "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10080,6 +10210,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10128,13 +10259,15 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16806,20 +16939,12 @@
       }
     },
     "polymer-siren-test-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/polymer-siren-test-helpers/-/polymer-siren-test-helpers-1.0.0.tgz",
-      "integrity": "sha512-3VTTXOiWaI2nBorwv+1OKMUqmXlEkWm/HLZ2I8BhrH0wuAa8dwMBAKo3KXg6TmUrH7CELcUw+I1rKmgnnafJGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/polymer-siren-test-helpers/-/polymer-siren-test-helpers-2.0.0.tgz",
+      "integrity": "sha512-L3WLy5pByD1iwT4JFomlwjxXG/FeTYhhDMszYkJn4Ci0sL1c9ooGYSd+6fPGSk331R7EO13s1nUqAywJXdN3qg==",
       "dev": true,
       "requires": {
-        "siren-parser": "^7.1.0"
-      },
-      "dependencies": {
-        "siren-parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/siren-parser/-/siren-parser-7.1.0.tgz",
-          "integrity": "sha512-hTzBFthHDsjERNceKmqSYAbC7rbPVMYQGBMXDmpPIRU+qABXg/EqrQt8UbLUZw08j3v7LzWXhiSSYpymLCHSoA==",
-          "dev": true
-        }
+        "siren-parser": "^8.0.0"
       }
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-merge-json": "^1.3.1",
     "plop": "^2.0.0",
     "polymer-cli": "^1.9.5",
-    "polymer-siren-test-helpers": "^1.0.0",
+    "polymer-siren-test-helpers": "^2.0.0",
     "wct-browser-legacy": "^1.0.1"
   },
   "version": "1.0.3",
@@ -46,15 +46,15 @@
   },
   "main": "d2l-sequences.js",
   "dependencies": {
-    "d2l-content-icons": "Brightspace/d2l-content-icons#semver:^3",
     "@polymer/polymer": "^3.0.0",
     "d2l-button": "BrightspaceUI/button#semver:^5",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
+    "d2l-content-icons": "Brightspace/d2l-content-icons#semver:^3",
     "d2l-link": "BrightspaceUI/link#semver:^5",
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^3",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
+    "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "s-html": "Brightspace/s-html#semver:^2.0.0"
   }
 }

--- a/test/d2l-sequences-automatic-completion-tracking-mixin.html
+++ b/test/d2l-sequences-automatic-completion-tracking-mixin.html
@@ -7,10 +7,7 @@
 	<title>d2l-completion-tracking-mixin test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 	<script src="../node_modules/chai-dom/chai-dom.js"></script>
-	<script type="module" src="../../@polymer/polymer/polymer-element.js"></script>
-	<script type="module" src="../mixins/d2l-sequences-automatic-completion-tracking-mixin.js"></script>
 </head>
 
 <body>
@@ -38,6 +35,8 @@ customElements.define(AutomaticCompletionTrackingTest.is, AutomaticCompletionTra
 	<script type="module">
 import '@polymer/polymer/polymer-element.js';
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-automatic-completion-tracking-mixin', () => {
 	let element;
 
@@ -49,7 +48,7 @@ describe('d2l-sequences-automatic-completion-tracking-mixin', () => {
 		const startCompletion = sinon.stub(element, 'startCompletion', () => {});
 		const finishCompletion = sinon.stub(element, 'finishCompletion', () => {});
 		const topicSetDashboardViewState = sinon.stub(element, 'topicSetDashboardViewState', () => {});
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		expect(startCompletion).to.have.been.called;
 		expect(topicSetDashboardViewState).to.have.been.called;
 		expect(finishCompletion).to.have.been.called;

--- a/test/d2l-sequences-completion-tracking-mixin.html
+++ b/test/d2l-sequences-completion-tracking-mixin.html
@@ -7,16 +7,14 @@
 	<title>d2l-completion-tracking-mixin test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 	<script src="../node_modules/chai-dom/chai-dom.js"></script>
-	<script type="module" src="../../@polymer/polymer/polymer-element.js"></script>
-	<script type="module" src="../mixins/d2l-sequences-completion-tracking-mixin.js"></script>
 </head>
 
 <body>
 	<script type="module">
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../mixins/d2l-sequences-completion-tracking-mixin.js';
+
 class CompletionTrackingTest extends D2L.Polymer.Mixins.Sequences.CompletionTrackingMixin(PolymerElement) {
 	static get is() {
 		return 'completion-tracking-test';
@@ -38,6 +36,8 @@ customElements.define(CompletionTrackingTest.is, CompletionTrackingTest);
 	<script type="module">
 import '@polymer/polymer/polymer-element.js';
 import '../mixins/d2l-sequences-completion-tracking-mixin.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-completion-tracking-mixin', () => {
 	let element;
 
@@ -65,7 +65,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 	it('startCompletion must perform siren action: view-activity-duration', async() => {
 		const performSirenAction = sinon.spy(element, 'performSirenAction');
 
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		element.startCompletion();
 
 		expect(performSirenAction).to.have.been.calledWithMatch({
@@ -76,7 +76,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 	it('topicSetDashboardViewState must perform siren action: set-dashboard-view-state', async() => {
 		const performSirenAction = sinon.spy(element, 'performSirenAction');
 
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		element.topicSetDashboardViewState();
 		expect(performSirenAction).to.have.been.calledWithMatch({
 			name: 'set-dashboard-view-state',
@@ -86,7 +86,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 	it('startCompletion must not perform completion tracking during impersonation', async() => {
 		const performViewActions = sinon.spy(element, '_performViewActions');
 
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		element.token = createFakeToken({
 			sub: 175,
 			actualsub: 169
@@ -99,7 +99,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 	it('finishCompletion must not perform completion tracking during impersonation', async() => {
 		const performViewActions = sinon.spy(element, '_performViewActions');
 
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		element.token = createFakeToken({
 			sub: 175,
 			actualsub: 169
@@ -112,7 +112,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 	it('finishCompletion must perform siren action: finish-view-activity', async() => {
 		const performSirenAction = sinon.spy(element, 'performSirenAction');
 
-		await SirenFixture.load('data/activity-completion-all.json', element);
+		await SirenFixture('data/activity-completion-all.json', element);
 		element._completionEntity = element.entity;
 		element.finishCompletion();
 

--- a/test/d2l-sequences-content-file-download.html
+++ b/test/d2l-sequences-content-file-download.html
@@ -6,9 +6,7 @@
 		<title>d2l-sequences-content-file-download test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
-		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script src="../node_modules/chai-dom/chai-dom.js"></script>
-		<script type="module" src="../components/d2l-sequences-content-file-download.js"></script>
 	</head>
 	<body>
 		<test-fixture id="FileFixture">
@@ -18,6 +16,8 @@
 		</test-fixture>
 		<script type="module">
 import { D2LSequencesContentFileDownload } from '../components/d2l-sequences-content-file-download.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-content-file-download', () => {
 	before(() => {
 		// skip completion tracking, preventing extraneous HTTP requests
@@ -30,13 +30,13 @@ describe('d2l-sequences-content-file-download', () => {
 	});
 
 	it('should have a form action matching the link href', async() => {
-		const element = await SirenFixture.load('data/activity-file-zip.json', fixture('FileFixture'));
+		const element = await SirenFixture('data/activity-file-zip.json', fixture('FileFixture'));
 		const form = element.shadowRoot.querySelector('form');
 		expect(form).to.have.attribute('action', 'data/test.zip');
 	});
 
 	it('Humansize should match expected values', async() => {
-		const element = await SirenFixture.load('data/activity-file-zip.json', fixture('FileFixture'));
+		const element = await SirenFixture('data/activity-file-zip.json', fixture('FileFixture'));
 		expect(element._getHumanFileSize(0)).to.equal('0 B');
 		expect(element._getHumanFileSize(1)).to.equal('1 B');
 		expect(element._getHumanFileSize(150)).to.equal('150 B');

--- a/test/d2l-sequences-content-file-html.html
+++ b/test/d2l-sequences-content-file-html.html
@@ -6,9 +6,7 @@
 		<title>d2l-sequences-content-file-html test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
-		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script src="../node_modules/chai-dom/chai-dom.js"></script>
-		<script type="module" src="../components/d2l-sequences-content-file-html.js"></script>
 	</head>
 	<body>
 		<test-fixture id="FileFixture">
@@ -18,6 +16,8 @@
 		</test-fixture>
 		<script type="module">
 import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-content-file-html', () => {
 	before(() => {
 		// skip completion tracking, preventing extraneous HTTP requests
@@ -25,7 +25,7 @@ describe('d2l-sequences-content-file-html', () => {
 	});
 
 	it('iframe source must match the file-activity src', async() => {
-		const element = await SirenFixture.load('data/activity-file-html.json', fixture('FileFixture'));
+		const element = await SirenFixture('data/activity-file-html.json', fixture('FileFixture'));
 		const iframe = element.shadowRoot.querySelector('iframe');
 		expect(iframe).to.have.attribute('src', '../test/data/test.html');
 	});

--- a/test/d2l-sequences-content-link-onedrive.html
+++ b/test/d2l-sequences-content-link-onedrive.html
@@ -6,9 +6,7 @@
 	<title>d2l-sequences-content-link test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 	<script src="../node_modules/chai-dom/chai-dom.js"></script>
-	<script type="module" src="../components/d2l-sequences-content-link-onedrive.js"></script>
 </head>
 <body>
 <test-fixture id="LinkFixture">
@@ -18,6 +16,8 @@
 </test-fixture>
 <script type="module">
 import { D2LSequencesContentLinkOnedrive } from '../components/d2l-sequences-content-link-onedrive.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-content-link-onedrive', () => {
 	before(() => {
 		// skip completion tracking, preventing extraneous HTTP requests
@@ -25,7 +25,7 @@ describe('d2l-sequences-content-link-onedrive', () => {
 	});
 
 	it('should have the correct onclick function', async() => {
-		const element = await SirenFixture.load('data/activity-link-onedrive.json', fixture('LinkFixture'));
+		const element = await SirenFixture('data/activity-link-onedrive.json', fixture('LinkFixture'));
 		const button = element.shadowRoot.querySelector('d2l-button');
 		expect(button).to.exist;
 		expect(button).to.have.attribute('onclick', 'window.open(\'https://example.bspc.com/d2l/le/content/contentservice/Forward/00000000-0000-0000-000000000000?linkId=1354&ou=%7BorgUnitId%7D\')');

--- a/test/d2l-sequences-content-link-scorm.html
+++ b/test/d2l-sequences-content-link-scorm.html
@@ -6,9 +6,7 @@
 	<title>d2l-sequences-content-link test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 	<script src="../node_modules/chai-dom/chai-dom.js"></script>
-	<script type="module" src="../components/d2l-sequences-content-link-scorm.js"></script>
 </head>
 <body>
 <test-fixture id="LinkFixture">
@@ -18,6 +16,8 @@
 </test-fixture>
 <script type="module">
 import { D2LSequencesContentLinkScorm } from '../components/d2l-sequences-content-link-scorm.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-content-link-scorm', () => {
 	before(() => {
 		// skip completion tracking, preventing extraneous HTTP requests
@@ -25,7 +25,7 @@ describe('d2l-sequences-content-link-scorm', () => {
 	});
 
 	it('should have the correct onclick function', async() => {
-		const element = await SirenFixture.load('data/activity-link-scorm.json', fixture('LinkFixture'));
+		const element = await SirenFixture('data/activity-link-scorm.json', fixture('LinkFixture'));
 		const button = element.shadowRoot.querySelector('d2l-button');
 		expect(button).to.exist;
 		expect(button).to.have.attribute('onclick', 'window.open(\'https://example.bspc.com/d2l/le/content/contentservice/Forward/00000000-0000-0000-000000000000?linkId=1354&ou=%7BorgUnitId%7D\')');

--- a/test/d2l-sequences-content-link.html
+++ b/test/d2l-sequences-content-link.html
@@ -6,9 +6,7 @@
 		<title>d2l-sequences-content-link test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
-		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script src="../node_modules/chai-dom/chai-dom.js"></script>
-		<script type="module" src="../components/d2l-sequences-content-link.js"></script>
 	</head>
 	<body>
 		<test-fixture id="LinkFixture">
@@ -18,6 +16,8 @@
 		</test-fixture>
 		<script type="module">
 import { D2LSequencesContentLink } from '../components/d2l-sequences-content-link.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-content-link', () => {
 	before(() => {
 		// skip completion tracking, preventing extraneous HTTP requests
@@ -25,13 +25,13 @@ describe('d2l-sequences-content-link', () => {
 	});
 
 	it('iframe src must match the link-activity src', async() => {
-		const element = await SirenFixture.load('data/activity-link.json', fixture('LinkFixture'));
+		const element = await SirenFixture('data/activity-link.json', fixture('LinkFixture'));
 		const src = element.shadowRoot.querySelector('iframe').getAttribute('src');
 		expect(src).to.equal('data/quicklink.html');
 	});
 
 	it('displays iframe content once spinner is hidden', done => {
-		SirenFixture.load('data/activity-link.json', fixture('LinkFixture')).then(element => {
+		SirenFixture('data/activity-link.json', fixture('LinkFixture')).then(element => {
 			const iframe = element.shadowRoot.querySelector('iframe');
 			setTimeout(() => {
 				expect(iframe).not.to.have.class('hide');

--- a/test/d2l-sequences-content-router.html
+++ b/test/d2l-sequences-content-router.html
@@ -6,9 +6,6 @@
 		<title>d2l-sequences-content-router test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
-		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
-		<script type="module" src="./loadFileWithDelay.js"></script>
-		<script type="module" src="../components/d2l-sequences-content-router.js"></script>
 	</head>
 	<body>
 		<test-fixture id="RouterFixture">
@@ -17,70 +14,76 @@
 			</template>
 		</test-fixture>
 		<script type="module">
-import './loadFileWithDelay.js';
+import loadFileWithDelay from './loadFileWithDelay.js';
 import '../components/d2l-sequences-content-router.js';
+import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
+import { D2LSequencesContentFileDownload } from '../components/d2l-sequences-content-file-download.js';
+import { D2LSequencesContentLink } from '../components/d2l-sequences-content-link';
+import { D2LSequencesContentLinkMixed } from '../components/d2l-sequences-content-link-mixed';
+import { D2LSequencesContentLinkScorm } from '../components/d2l-sequences-content-link-scorm';
+import { D2LSequencesContentLinkOnedrive } from '../components/d2l-sequences-content-link-onedrive';
 describe('d2l-sequences-content-router', () => {
 	describe('should handle a file activity for the mimetype:', () => {
 		it('application/pdf', async() => {
 			const element = await loadFileWithDelay('data/activity-file-pdf.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('image/bmp', async() => {
 			const element = await loadFileWithDelay('data/activity-file-bmp.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('should handle image/gif', async() => {
 			const element = await loadFileWithDelay('data/activity-file-gif.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('should handle image/jpeg', async() => {
 			const element = await loadFileWithDelay('data/activity-file-jpeg.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('should handle image/png', async() => {
 			const element = await loadFileWithDelay('data/activity-file-png.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('should handle image/svg+xml', async() => {
 			const element = await loadFileWithDelay('data/activity-file-svg.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 
 		it('text/html', async() => {
 			const element = await loadFileWithDelay('data/activity-file-html.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
 		});
 	});
 
 	describe('should handle file activity types for unregistered mimetypes:', () => {
 		it('such as application/zip', async() => {
 			const element = await loadFileWithDelay('data/activity-file-zip.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-html')).not.to.exist;
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-file-download')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).not.to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentFileDownload.is)).to.exist;
 		});
 	});
 
 	describe('should handle link activities', () => {
 		it('should handle mixed security links', async() => {
 			const element = await loadFileWithDelay('data/activity-link-insecure.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-link')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentLink.is)).to.exist;
 		});
 		it('should handle normal links', async() => {
 			const element = await loadFileWithDelay('data/activity-link-secure.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-link-mixed')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentLinkMixed.is)).to.exist;
 		});
 		it('should handle scorm links', async() => {
 			const element = await loadFileWithDelay('data/activity-link-scorm.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-link-scorm')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentLinkScorm.is)).to.exist;
 		});
 		it('should handle onedrive links', async() => {
 			const element = await loadFileWithDelay('data/activity-link-onedrive.json');
-			expect(element.shadowRoot.querySelector('d2l-sequences-content-link-onedrive')).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentLinkOnedrive.is)).to.exist;
 		});
 	});
 });

--- a/test/d2l-sequences-iterator.html
+++ b/test/d2l-sequences-iterator.html
@@ -6,9 +6,7 @@
 		<title>d2l-sequences-iterator test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
-		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script src="../node_modules/chai-dom/chai-dom.js"></script>
-		<script type="module" src="../components/d2l-sequences-iterator.js"></script>
 	</head>
 	<body>
 		<test-fixture id="basic">
@@ -22,42 +20,44 @@
 			</template>
 		</test-fixture>
 		<script type="module">
-	describe('d2l-sequences-iterator', () => {
-		let elem;
+			import { D2LSequencesIterator } from '../components/d2l-sequences-iterator.js';
+			import SirenFixture from 'polymer-siren-test-helpers';
 
-		it('should instantiate the element', async() => {
-			elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('basic'));
-			expect(elem.tagName).to.equal('D2L-SEQUENCES-ITERATOR');
-			expect(elem.entity).not.to.be.null;
-		});
+describe('d2l-sequences-iterator', () => {
+	let elem;
 
-		it('should be enabled when entity contains next', async() => {
-			elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('basic'));
-			elem.setAttribute('next', true);
-			expect(elem.disabled).not.to.be.true;
-		});
-
-		it('should be enabled when entity contains previous', async() => {
-			elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('basic'));
-			elem.setAttribute('previous', true);
-			expect(elem.disabled).not.to.be.true;
-		});
-
-		it('should update the link href when iterator is clicked', async() => {
-			elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('basic'));
-			expect(elem.href).to.equal('../demo/data/l2-m1-activity1.json');
-
-			elem.shadowRoot.querySelector('d2l-navigation-button-notification-icon')
-				.click();
-			expect(elem.href).to.equal('../demo/data/l2-m1-activity1.json');
-		});
-
-		it('should be disabled when iterator is set to disabled', async() => {
-			const noNextPrevious = fixture('disabled');
-			expect(noNextPrevious.disabled).to.be.true;
-			expect(noNextPrevious.shadowRoot.querySelector('#iteratorButton').getAttribute('aria-disabled')).to.be.exist;
-		});
+	it('should instantiate the element', async() => {
+		elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('basic'));
+		expect(elem.tagName.toLowerCase()).to.equal(D2LSequencesIterator.is);
+		expect(elem.entity).not.to.be.null;
 	});
+
+	it('should be enabled when entity contains next', async() => {
+		elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('basic'));
+		elem.setAttribute('next', true);
+		expect(elem.disabled).not.to.be.true;
+	});
+
+	it('should be enabled when entity contains previous', async() => {
+		elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('basic'));
+		elem.setAttribute('previous', true);
+		expect(elem.disabled).not.to.be.true;
+	});
+
+	it('should update the link href when iterator is clicked', async() => {
+		elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('basic'));
+		expect(elem.href).to.equal('../demo/data/l2-m1-activity1.json');
+
+		elem.shadowRoot.querySelector('d2l-navigation-button-notification-icon').click();
+		expect(elem.href).to.equal('../demo/data/l2-m1-activity1.json');
+	});
+
+	it('should be disabled when iterator is set to disabled', async() => {
+		const noNextPrevious = fixture('disabled');
+		expect(noNextPrevious.disabled).to.be.true;
+		expect(noNextPrevious.shadowRoot.querySelector('#iteratorButton').getAttribute('aria-disabled')).to.be.exist;
+	});
+});
 	</script>
 	</body>
 </html>

--- a/test/d2l-sequences-module-name.html
+++ b/test/d2l-sequences-module-name.html
@@ -7,8 +7,6 @@
 	<title>d2l-sequences-module-name test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
-	<script type="module" src="../components/d2l-sequences-module-name.js"></script>
 </head>
 
 <body>
@@ -25,15 +23,17 @@
 	</test-fixture>
 
 	<script type="module">
-import '../components/d2l-sequences-module-name.js';
+import { D2LSequencesModuleName } from '../components/d2l-sequences-module-name.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-module-name', () => {
 	it('should instantiate the element', () => {
 		const elem = fixture('basic');
-		expect(elem.tagName).to.equal('D2L-SEQUENCES-MODULE-NAME');
+		expect(elem.tagName.toLowerCase()).to.equal(D2LSequencesModuleName.is);
 	});
 
 	it('should instantiate the element', async() => {
-		const elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('lessBasic'));
+		const elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('lessBasic'));
 		expect(elem.entity).not.to.equal(null);
 	});
 });

--- a/test/d2l-sequences-topic-name.html
+++ b/test/d2l-sequences-topic-name.html
@@ -7,8 +7,6 @@
 	<title>d2l-sequences-topic-name test</title>
 	<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="../../wct-browser-legacy/browser.js"></script>
-	<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
-	<script type="module" src="../components/d2l-sequences-topic-name.js"></script>
 </head>
 
 <body>
@@ -25,15 +23,17 @@
 	</test-fixture>
 
 	<script type="module">
-import '../components/d2l-sequences-topic-name.js';
+import { D2LSequencesTopicName } from '../components/d2l-sequences-topic-name.js';
+import SirenFixture from 'polymer-siren-test-helpers';
+
 describe('d2l-sequences-topic-name', () => {
 	it('should instantiate the element', () => {
 		const elem = fixture('basic');
-		expect(elem.tagName).to.equal('D2L-SEQUENCES-TOPIC-NAME');
+		expect(elem.tagName.toLowerCase()).to.equal(D2LSequencesTopicName.is);
 	});
 
 	it('should display the title', async() => {
-		const elem = await SirenFixture.load('../demo/data/l2-m1-activity1.json', fixture('lessBasic'));
+		const elem = await SirenFixture('../demo/data/l2-m1-activity1.json', fixture('lessBasic'));
 		expect(elem.title).to.equal('Accessible Word Document');
 	});
 });

--- a/test/loadFileWithDelay.js
+++ b/test/loadFileWithDelay.js
@@ -1,15 +1,15 @@
+import SirenFixture from 'polymer-siren-test-helpers';
+
 async function delay(time) {
 	return new Promise(resolve => {
 		setTimeout(resolve, time);
 	});
 }
 
-async function loadFileWithDelay(filename) {
-	const element = await SirenFixture.load(filename, fixture('RouterFixture'));
+export default async function loadFileWithDelay(filename) {
+	const element = await SirenFixture(filename, fixture('RouterFixture'));
 
 	await delay(250);
 
 	return element;
 }
-
-window.loadFileWithDelay = loadFileWithDelay;


### PR DESCRIPTION
Use Element.is instead of hard coding element tags
Update polymer-siren-test-helpers to version 2 to support ES6 modules