### PR TITLE
Remove references to set-dashboard-state-view siren action

### DIFF
--- a/components/d2l-sequences-content-link-mixed.js
+++ b/components/d2l-sequences-content-link-mixed.js
@@ -78,7 +78,6 @@ export class D2LSequencesContentLinkMixed extends D2L.Polymer.Mixins.Sequences.C
 		}
 
 		this.startCompletion();
-		this.topicSetDashboardViewState();
 		return window.open(location);
 	}
 }

--- a/components/d2l-sequences-content-module.js
+++ b/components/d2l-sequences-content-module.js
@@ -1,6 +1,5 @@
 import './d2l-sequences-module-name.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { Maybe } from '../maybe.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import 'd2l-typography/d2l-typography.js';
@@ -47,8 +46,7 @@ export class D2LSequencesContentModule extends mixinBehaviors([
 
 	static get observers() {
 		return [
-			'_getDescription(entity)',
-			'_moduleSetDashboardViewState(entity)'
+			'_getDescription(entity)'
 		];
 	}
 
@@ -58,24 +56,6 @@ export class D2LSequencesContentModule extends mixinBehaviors([
 		}
 
 		this.$.description.innerHTML = entity.properties.description;
-	}
-
-	_moduleSetDashboardViewState(entity) {
-		if (!entity) {
-			return;
-		}
-		return new Promise((resolve, reject) => {
-			const action = Maybe.of(entity)
-				.chain(
-					a => a.getActionByName('set-dashboard-view-state')
-				);
-			if (action.isNothing()) {
-				return reject(entity, 'no action found');
-			}
-
-			return this.performSirenAction(action.value)
-				.then(resolve);
-		});
 	}
 }
 

--- a/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
@@ -33,7 +33,6 @@ function AutomaticCompletionTrackingMixin() {
 			if (this.href !== this._previousHref) {
 				this.finishCompletion();
 				this.startCompletion();
-				this.topicSetDashboardViewState();
 				this._previousHref = this.href;
 			}
 		}

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -28,13 +28,6 @@ function CompletionTrackingMixin() {
 			};
 		}
 
-		topicSetDashboardViewState() {
-			if (!this.entity) {
-				return;
-			}
-			this._performViewActions(this.entity, 'set-dashboard-view-state');
-		}
-
 		finishCompletion() {
 			this._fireToastEvent();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/d2l-sequences-automatic-completion-tracking-mixin.html
+++ b/test/d2l-sequences-automatic-completion-tracking-mixin.html
@@ -44,13 +44,11 @@ describe('d2l-sequences-automatic-completion-tracking-mixin', () => {
 		element = fixture('MixinFixture');
 	});
 
-	it('startCompletion, topicSetDashboardViewState and finishCompletion must be called when element is updated', async() => {
+	it('startCompletion and finishCompletion must be called when element is updated', async() => {
 		const startCompletion = sinon.stub(element, 'startCompletion', () => {});
 		const finishCompletion = sinon.stub(element, 'finishCompletion', () => {});
-		const topicSetDashboardViewState = sinon.stub(element, 'topicSetDashboardViewState', () => {});
 		await SirenFixture('data/activity-completion-all.json', element);
 		expect(startCompletion).to.have.been.called;
-		expect(topicSetDashboardViewState).to.have.been.called;
 		expect(finishCompletion).to.have.been.called;
 	});
 });

--- a/test/d2l-sequences-completion-tracking-mixin.html
+++ b/test/d2l-sequences-completion-tracking-mixin.html
@@ -73,16 +73,6 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 		});
 	});
 
-	it('topicSetDashboardViewState must perform siren action: set-dashboard-view-state', async() => {
-		const performSirenAction = sinon.spy(element, 'performSirenAction');
-
-		await SirenFixture('data/activity-completion-all.json', element);
-		element.topicSetDashboardViewState();
-		expect(performSirenAction).to.have.been.calledWithMatch({
-			name: 'set-dashboard-view-state',
-		});
-	});
-
 	it('startCompletion must not perform completion tracking during impersonation', async() => {
 		const performViewActions = sinon.spy(element, '_performViewActions');
 

--- a/test/data/activity-completion-all.json
+++ b/test/data/activity-completion-all.json
@@ -56,10 +56,6 @@
 			"name": "view-activity-duration",
 			"method": "PUT",
 			"href": "https://00000000-0000-0000-0000-000000000000.sequences.api.proddev.d2l/6614/activity/97674/view"
-		},{
-			"name": "set-dashboard-view-state",
-			"method": "PUT",
-			"href": "https://00000000-0000-0000-0000-000000000000.sequences.api.proddev.d2l/6614/activity/97674/set-dashboard-view-state"
 		}]
 	}],
 	"links": [{


### PR DESCRIPTION
This siren action no longer exists in the response. The logic behind this action has been added to set-last-viewed-content-object. 