### PR TITLE
Sequence module list to use SDK

### DIFF
--- a/components/d2l-sequences-module-list.js
+++ b/components/d2l-sequences-module-list.js
@@ -145,7 +145,7 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 			},
 			_modulesBySequence: {
 				type: Array,
-				value: function() { return {}; }
+				value: function() { return []; }
 			},
 			_modules: {
 				type: Array,

--- a/components/d2l-sequences-module-list.js
+++ b/components/d2l-sequences-module-list.js
@@ -143,10 +143,6 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 				type: String,
 				value: 'd2l-tier1:arrow-collapse'
 			},
-			_modulesBySequence: {
-				type: Array,
-				value: function() { return []; }
-			},
 			_modules: {
 				type: Array,
 				value: function() { return []; }
@@ -191,11 +187,12 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 	}
 
 	_onSequenceRootChange(sequenceRoot) {
+		const modulesBySequence = [];
 		sequenceRoot.onSubSequencesChange((subSequence) => {
-			this._modulesBySequence[subSequence.index()] = {
+			modulesBySequence[subSequence.index()] = {
 				title: subSequence.title()
 			};
-			this._modules = this._modulesBySequence.filter(element => typeof(element) !== 'undefined');
+			this._modules = modulesBySequence.filter(element => typeof(element) !== 'undefined');
 		});
 	}
 

--- a/components/d2l-sequences-module-list.js
+++ b/components/d2l-sequences-module-list.js
@@ -8,7 +8,6 @@ import 'd2l-icons/d2l-icon.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import './d2l-sequences-module-name.js';
 import '../localize-behavior.js';
 
 const behaviors = [

--- a/components/d2l-sequences-module-list.js
+++ b/components/d2l-sequences-module-list.js
@@ -143,6 +143,10 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 				type: String,
 				value: 'd2l-tier1:arrow-collapse'
 			},
+			_modulesBySequence: {
+				type: Array,
+				value: function() { return {}; }
+			},
 			_modules: {
 				type: Array,
 				value: function() { return []; }
@@ -188,11 +192,10 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 
 	_onSequenceRootChange(sequenceRoot) {
 		sequenceRoot.onSubSequencesChange((subSequence) => {
-			const modules = this._modules;
-			modules[subSequence.index()] = {
+			this._modulesBySequence[subSequence.index()] = {
 				title: subSequence.title()
 			};
-			this._modules = modules.filter(element => typeof(element) !== 'undefined');
+			this._modules = this._modulesBySequence.filter(element => typeof(element) !== 'undefined');
 		});
 	}
 

--- a/components/d2l-sequences-module-list.js
+++ b/components/d2l-sequences-module-list.js
@@ -143,10 +143,6 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 				type: String,
 				value: 'd2l-tier1:arrow-collapse'
 			},
-			_modulesBySequence: {
-				type: Object,
-				value: function() { return {}; }
-			},
 			_modules: {
 				type: Array,
 				value: function() { return []; }
@@ -192,10 +188,11 @@ class D2lSequenceModuleList extends mixinBehaviors(behaviors, EntityMixin(Polyme
 
 	_onSequenceRootChange(sequenceRoot) {
 		sequenceRoot.onSubSequencesChange((subSequence) => {
-			this._modulesBySequence[subSequence.index()] = {
+			const modules = this._modules;
+			modules[subSequence.index()] = {
 				title: subSequence.title()
 			};
-			this._modules = Object.keys(this._modulesBySequence).sort((a, b) => a < b).map(index => this._modulesBySequence[index]);
+			this._modules = modules.filter(element => typeof(element) !== 'undefined');
 		});
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17968,6 +17968,14 @@
       "resolved": "https://registry.npmjs.org/siren-parser/-/siren-parser-8.2.0.tgz",
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
+    "siren-sdk": {
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#dea12a400f4c1cd40194cb64ba7d99f253f06f7d",
+      "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -18536,9 +18544,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "polymer-google-drive-viewer": "Brightspace/polymer-google-drive-viewer#semver:^3",
-    "s-html": "Brightspace/s-html#semver:^2"
+    "s-html": "Brightspace/s-html#semver:^2",
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^3.0.0"
   },
-  "version": "1.2.1",
+  "version": "1.3.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Requires: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/41

Convert the `d2l-sequence-module-list` to use the new sdk!