### PR TITLE
DE36107: HTML content topics do not scroll on ipads/iphones

### DIFF
--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -36,7 +36,6 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 				type: String,
 				computed: '_getFileLocation(entity)'
 			},
-			thing: String,
 			title: {
 				type: String,
 				computed: '_getTitle(entity)'

--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -4,13 +4,20 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 	static get template() {
 		return html`
 		<style>
+			.d2l-sequences-scroll-container {
+				-webkit-overflow-scrolling: touch;
+				overflow-y: auto;
+				height: 100%;
+			}
 			iframe {
 				width: 100%;
 				height: calc(100% - 12px);
 				overflow: hidden;
 			}
 		</style>
-		<iframe id="content" frameborder="0" src$="[[_fileLocation]]" title$="[[title]]"></iframe>
+		<div class="d2l-sequences-scroll-container">
+			<iframe id="content" frameborder="0" src$="[[_fileLocation]]" title$="[[title]]"></iframe>
+		</div>
 `;
 	}
 
@@ -29,6 +36,7 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 				type: String,
 				computed: '_getFileLocation(entity)'
 			},
+			thing: String,
 			title: {
 				type: String,
 				computed: '_getTitle(entity)'

--- a/demo/d2l-sequences-content-file-html.html
+++ b/demo/d2l-sequences-content-file-html.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+	<title>D2L Sequences Content File HTML</title>
+	<script type="module" src="../components/d2l-sequences-content-file-html.js"></script>
+</head>
+
+<body>
+	<d2l-sequences-content-file-html
+		href="../demo/data/example-with-html-doc.json"
+		token="token"
+		title="Content File HTML Title"
+	>
+	</d2l-sequences-content-file-html>
+</body>
+
+</html>

--- a/demo/data/example-with-html-doc.json
+++ b/demo/data/example-with-html-doc.json
@@ -4,7 +4,7 @@
 	"links": [
 		{
 			"rel": ["self"],
-			"href": "data/example2.json"
+			"href": "data/example-with-html-doc.json"
 		}
 	],
 	"entities": [

--- a/demo/data/example-with-html-doc.json
+++ b/demo/data/example-with-html-doc.json
@@ -1,0 +1,24 @@
+{
+	"class": ["example"],
+	"properties": { "title": "Example With HTML Document" },
+	"links": [
+		{
+			"rel": ["self"],
+			"href": "data/example2.json"
+		}
+	],
+	"entities": [
+		{
+			"class": ["activity", "file-activity"],
+			"rel": ["about"],
+			"entities": [{
+				"class": ["file"],
+				"rel": ["about"],
+				"links": [{
+					"rel": ["alternate"],
+					"href": "./data/long-html-doc.html"
+				}]
+			}]
+		}
+	]
+}

--- a/demo/data/long-html-doc.html
+++ b/demo/data/long-html-doc.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+	<h1>This document is really long so we can see that scrolling always works</h1>
+	<h3>P1</h3>
+	<p>
+		The loyal protein fasts. The monopoly strikes around his clipped cinema. Should the rat fake the mad earth? A hardship excepts the wild.
+		The closet rockets? The stiff nests our mayor. The custom heritage horns an offensive ally. Beneath the copper raves the flood drivel. A shoe loses without a countryside.
+		The small compromise hums beneath a chalk. Any angry visitor alters a releasing clue. The representative consents with the capital legend. A flower eyes the sponsor below the inheriting litter.
+	</p>
+	<h3>P2</h3>
+	<p>
+		The darling pedestrian solos. Under our module swings the passionate master. The severe moan connects an unfortunate heat. The operational trouble offends underneath a crass acid.
+		The spirit bubbles underneath our joke. The shout concedes the sink. The bow deterrent profiles a firework above the tired twin. Another concern replies to the cage. Will the mild ice bench the recovery?
+		The regarding liaison meets the bankrupt. The hassle originates across the beat objective. The cough prosecutes before the pro. Near the official coasts the hazard.
+	</p>
+	<h3>P3</h3>
+	<p>
+		Each sacked mouth freezes outside the pathetic chamber. The different significance tempers the panel. The filter punts after the flipping continuum. The cant collective bounces.
+		The ugly groan pulps the serious glove. A well aardvark pretends to be my substantial chairman. The concerned biology invests the hydrogen. The cookie chooses!
+		How can the ballot run in the bananas extract? The thoroughfare shouts within the satisfying defect. The brown universe argues. The gathered viewer worries. A hook parades above the shower! The trend locks a sabotage.
+	</p>
+	<h3>P4</h3>
+	<p>
+		How does the hatred peer? An unhappy borderline attends on top of the wooden sky. The anguish faints across the pedant. A stark effort rails. The amazing genocide bicycles opposite an ass. The shareholder sleeps over the matched chart.
+		The raving cotton declines outside the corrupted cheese. Can a homosexual smile cramp a lens? The equivalent incentive tenders the concerto. A curse results?
+		The dropped export fumes with the breath. Before its misuse screams the mechanic kettle. A pleasing bucket rattles without a honey demise. The farmer delights the pointing ghost.
+	</p>
+	<h3>P5</h3>
+	<p>
+		Near the disliked ear jokes a considered mirror. Can a transformation vanish past the wearing gentleman? This dismissed associate dies on top of its tobacco. The mixed peripheral weighs the scratched breakfast. The wetting talent alleges a guideline. The racial autumn boxes a neighborhood.
+		A thought twists a partner. The approval struggles without every corrected comic. The participant faces my exponential. A scum triumphs inside the sundry. The literature accepts outside another drill. The monster opens a disturbed resemblance inside the algebra.
+		The mate includes the shock romantic. Can this authentic machine stir beside the innocence? The jungle bumps a fluffy calendar. The consulting campaign dances after the rash insult. Near a mathematical volunteer chews a filmed charm.
+	</p>
+	<h2>END OF DOCUMENT</h2>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,8 +42,7 @@
 					<d2l-sequences-module-name href="data/l2-module1.json" token="foo"></d2l-sequences-module-name>
 				</template>
 			</demo-snippet>
-			
-		
+
 			<h3>d2l-sequences-topic-name</h3>
 			<demo-snippet>
 				<template>
@@ -95,6 +94,7 @@
 
 			<h3>More demos:</h3>
 			<ul>
+				<li><a href="d2l-sequences-content-file-html.html">d2l-sequences-content-file-html</a></li>
 				<li><a href="d2l-sequences-content-html-multipage.html">d2l-sequences-content-html-multipage</a></li>
 				<li><a href="d2l-sequences-content-link-mixed.html">d2l-sequences-content-link-mixed</a></li>
 				<li><a href="d2l-sequences-content-link-scorm.html">d2l-sequences-content-link-scorm</a></li>


### PR DESCRIPTION
- Wrapped the iframe in a div with certain css properties to allow scrolling on iOS.
- Made a demo for this component since it did not already exist.

(Images are examples from Chrome demonstrating the new demo)

![image](https://user-images.githubusercontent.com/14796305/65438778-aeba2a80-ddeb-11e9-9df5-bc727232ed4d.png)
![image](https://user-images.githubusercontent.com/14796305/65438839-c7c2db80-ddeb-11e9-8202-2f989304643c.png)
