### PR TITLE
DE36119: Module description max width causes scrollbar to be in the middle of the viewer

### DIFF
--- a/components/d2l-sequences-content-module.js
+++ b/components/d2l-sequences-content-module.js
@@ -3,6 +3,7 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import 'd2l-typography/d2l-typography.js';
+
 export class D2LSequencesContentModule extends mixinBehaviors([
 	D2L.PolymerBehaviors.Siren.EntityBehavior,
 	D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl
@@ -11,11 +12,12 @@ export class D2LSequencesContentModule extends mixinBehaviors([
 		return html`
 		<style include="d2l-typography">
 		:host {
-			max-width: 678px;
-			margin: auto;
 			display: block;
 		}
 
+		.d2l-module-container {
+			max-width: 678px;
+		}
 		.d2l-sequences-module-name {
 			border-bottom: 1px solid #ddd;
 			padding-bottom: 30px;

--- a/components/d2l-sequences-content-router.js
+++ b/components/d2l-sequences-content-router.js
@@ -20,9 +20,7 @@ import { isMobile, isIOS, isSafari } from '../util/util.js';
 
 class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin(getEntityType) {
 	static get template() {
-		return html`
-
-`;
+		return html``;
 	}
 
 	static get is() {


### PR DESCRIPTION
- Adjust some styling so that the scroll bar is not in the middle of the module. Now it is on the outside of it.

### DEPENDENCIES:

d2l-sequence-viewer: https://github.com/Brightspace/d2l-sequence-viewer/pull/219

### SCREEN SHOTS:

![scrollbar1](https://user-images.githubusercontent.com/14796305/65720462-99543300-e06d-11e9-862e-ea25a99f94f4.png)

![scrollbar2](https://user-images.githubusercontent.com/14796305/65720471-9c4f2380-e06d-11e9-94e0-a7cf6183241e.png)
