### PR TITLE
DE36119: Module description max width causes scrollbar to be in the middle of the viewer (margins)

### DIFF
--- a/components/d2l-sequences-content-module.js
+++ b/components/d2l-sequences-content-module.js
@@ -17,6 +17,7 @@ export class D2LSequencesContentModule extends mixinBehaviors([
 
 		.d2l-module-container {
 			max-width: 678px;
+			margin: auto;
 		}
 		.d2l-sequences-module-name {
 			border-bottom: 1px solid #ddd;


### PR DESCRIPTION
Adding back the `margin: auto` property to center the content in the middle of the viewer. I'm really not sure why I removed it. :(

### SCREENSHOTS:

![scrollbarfix2-1](https://user-images.githubusercontent.com/14796305/65968768-aab48b00-e431-11e9-8cdc-77c1065f88fa.PNG)

![Annotation 2019-10-01 095357](https://user-images.githubusercontent.com/14796305/65968774-ae481200-e431-11e9-83a1-086d19ac0cce.png)

![scrollbarfix2-2](https://user-images.githubusercontent.com/14796305/65968805-ba33d400-e431-11e9-8b0c-11aae3931b59.PNG)