### PR TITLE
@d2l/content-icons is a prebuilt package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1694,8 +1694,8 @@
       }
     },
     "d2l-content-icons": {
-      "version": "github:Brightspace/d2l-content-icons#7cccfda77ea56544be038276decad8d4d307bdc0",
-      "from": "github:Brightspace/d2l-content-icons#semver:^3",
+      "version": "3.0.1",
+      "resolved": "github:Brightspace/d2l-content-icons#7cccfda77ea56544be038276decad8d4d307bdc0",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@polymer/polymer": "^3.0.0",
     "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-content-icons": "Brightspace/d2l-content-icons#semver:^3",
+    "d2l-content-icons": "^3.0.0",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-link": "BrightspaceUI/link#semver:^5",


### PR DESCRIPTION
* Yes it breaks the convention of other packages, but since other
  packages use the ^3.0.0 version, using this package breaks the
  dependency resolution