### PR TITLE
DE37195 Ensure iframe unloads before removed from page

### DIFF
--- a/components/d2l-sequences-content-link.js
+++ b/components/d2l-sequences-content-link.js
@@ -51,7 +51,7 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 			previousHref: {
 				type: String
 			},
-			unload: {
+			isUnloaded: {
 				type: Boolean
 			},
 			_linkLocation: {
@@ -61,7 +61,7 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		};
 	}
 	static get observers() {
-		return ['_render(entity)', '_unload(unload)'];
+		return ['_render(entity)', '_unload(isUnloaded)'];
 	}
 
 	connectedCallback() {
@@ -128,8 +128,8 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		};
 	}
 
-	_unload(unload) {
-		if (unload) {
+	_unload(isUnloaded) {
+		if (isUnloaded) {
 			const contentFrame = this.shadowRoot.querySelector('#content');
 			contentFrame.src = '';
 		}

--- a/components/d2l-sequences-content-link.js
+++ b/components/d2l-sequences-content-link.js
@@ -70,6 +70,8 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-sequence-viewer-multipage-navigation', this.multiPageNavListener);
 		window.postMessage(JSON.stringify({ handler: 'd2l.nav.reset' }), '*');
+		debugger;
+		this.href = undefined;
 	}
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);

--- a/components/d2l-sequences-content-link.js
+++ b/components/d2l-sequences-content-link.js
@@ -70,7 +70,6 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-sequence-viewer-multipage-navigation', this.multiPageNavListener);
 		window.postMessage(JSON.stringify({ handler: 'd2l.nav.reset' }), '*');
-		debugger;
 		this.href = undefined;
 	}
 	_scrollToTop() {

--- a/components/d2l-sequences-content-link.js
+++ b/components/d2l-sequences-content-link.js
@@ -51,6 +51,9 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 			previousHref: {
 				type: String
 			},
+			unload: {
+				type: Boolean
+			},
 			_linkLocation: {
 				type: String,
 				computed: '_getLinkLocation(entity)'
@@ -58,7 +61,7 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		};
 	}
 	static get observers() {
-		return ['_render(entity)'];
+		return ['_render(entity)', '_unload(unload)'];
 	}
 
 	connectedCallback() {
@@ -70,7 +73,6 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-sequence-viewer-multipage-navigation', this.multiPageNavListener);
 		window.postMessage(JSON.stringify({ handler: 'd2l.nav.reset' }), '*');
-		this.href = undefined;
 	}
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
@@ -124,6 +126,13 @@ export class D2LSequencesContentLink extends D2L.Polymer.Mixins.Sequences.Automa
 			content.classList.remove('d2l-sequences-hide');
 			spinner.classList.add('d2l-sequences-hide');
 		};
+	}
+
+	_unload(unload) {
+		if (unload) {
+			const contentFrame = this.shadowRoot.querySelector('#content');
+			contentFrame.src = '';
+		}
 	}
 
 	_navigateMultiPageFile(e) {

--- a/mixins/d2l-sequences-router-mixin.js
+++ b/mixins/d2l-sequences-router-mixin.js
@@ -77,6 +77,7 @@ function RouterMixin(getEntityType) {
 						contentElement.appendChild(this._stampTemplate(nodeTemplate));
 
 						if (this._contentElement) {
+							this._contentElement.unload = true;
 							this.shadowRoot.removeChild(this._contentElement);
 						}
 

--- a/mixins/d2l-sequences-router-mixin.js
+++ b/mixins/d2l-sequences-router-mixin.js
@@ -77,7 +77,7 @@ function RouterMixin(getEntityType) {
 						contentElement.appendChild(this._stampTemplate(nodeTemplate));
 
 						if (this._contentElement) {
-							this._contentElement.unload = true;
+							this._contentElement.isUnloaded = true;
 							this.shadowRoot.removeChild(this._contentElement);
 						}
 


### PR DESCRIPTION
[Rally Defect](https://rally1.rallydev.com/#/289692574792d/detail/defect/356480369520)

Hooked into `d2l-sequences-router-mixin`'s `_render` function to set an `unload` flag before removing elements from the page, allowing `d2l-sequences-content-link` to unset its `iframe`'s `src` attribute and trigger `before/unload` events.