### PR TITLE
using localize-behavior's date formatting

### DIFF
--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -7,7 +7,6 @@ import 'd2l-accordion/d2l-accordion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import 'd2l-offscreen/d2l-offscreen.js';
-import d2lIntl from 'd2l-intl';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 /*
 @memberOf window.D2L.Polymer.Mixins;
@@ -419,9 +418,6 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 
 	getFormatedDate(entity) {
 
-		const formatter = new d2lIntl.DateTimeFormat(this.language, {
-			format: 'medium'
-		});
 		const currentDate = new Date();
 		let startDate;
 		let result = '';
@@ -440,15 +436,11 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 		}
 
 		if (startDate && startDate > currentDate) {
-			result = formatter.formatDate(
-				startDate
-			);
+			result = this.formatDate(startDate, {format: 'medium'});
 			return this.localize('sequenceNavigator.starts', 'startDate', result);
 		}
 		if (dueDate) {
-			result = formatter.formatDate(
-				dueDate
-			);
+			result = this.formatDate(dueDate,  {format: 'medium'});
 			return this.localize('sequenceNavigator.due', 'dueDate', result);
 		}
 		return result;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "d2l-accordion": "BrightspaceUI/accordion#semver:^1",
     "d2l-content-icons": "Brightspace/d2l-content-icons#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
-    "d2l-intl": "^2.1.0",
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",


### PR DESCRIPTION
Some major breaking changes (and improvements) are coming to the `d2l-intl` library. In going through places that are using it in preparation to fix them up, I noticed this usage.

Since this component is using the `localize-behavior` mixin, it already has a `formatDate` method it can just use.