### PR TITLE
Prevent children from rendering when accordion starts closed

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -176,7 +176,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		</style>
 
 		<d2l-labs-accordion-collapse no-icons="" flex="">
-			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
+			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" on-click="_onHeaderClicked" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>
 				<div class="border"></div>
 				<div class="module-header">
@@ -238,7 +238,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			subEntities: {
 				type: Array,
-				computed: 'getSubEntities(entity)'
+				computed: 'getSubEntities(entity, _accordionOpen)'
 			},
 			hasChildren: {
 				type: Boolean,
@@ -273,6 +273,10 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			_hideModuleDescription: {
 				type: Boolean,
 				computed: '_getHideModuleDescription(entity)'
+			},
+			_accordionOpen: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}
@@ -283,11 +287,13 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 	connectedCallback() {
 		super.connectedCallback();
+		this.addEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateHeaderClass);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
+		this.removeEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateHeaderClass);
 	}
 
@@ -340,8 +346,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._isOptionalModule();
 	}
 
-	getSubEntities(entity) {
-		return entity && entity.getSubEntities()
+	getSubEntities(entity, accordionOpen) {
+		return accordionOpen && entity && entity.getSubEntities()
 			.filter(subEntity => (subEntity.hasClass('sequenced-activity') && subEntity.hasClass('available')) || (subEntity.href && subEntity.hasClass('sequence-description')))
 			.map(this._getHref);
 	}
@@ -370,6 +376,10 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		if (childLink.class.includes('sequenced-activity') && this.currentActivity !== childLink.href) {
 			this.currentActivity = childLink.href;
 		}
+	}
+
+	_onHeaderClicked() {
+		this._accordionOpen = this._isAccordionOpen();
 	}
 
 	childIsActiveEvent() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -176,7 +176,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		</style>
 
 		<d2l-labs-accordion-collapse no-icons="" flex="">
-			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" on-click="_onHeaderClicked" is-sidebar$="[[isSidebar]]">
+			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>
 				<div class="border"></div>
 				<div class="module-header">
@@ -238,7 +238,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			subEntities: {
 				type: Array,
-				computed: 'getSubEntities(entity, _accordionOpen)'
+				computed: 'getSubEntities(entity, _allowChildrenRendering)'
 			},
 			hasChildren: {
 				type: Boolean,
@@ -274,7 +274,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				type: Boolean,
 				computed: '_getHideModuleDescription(entity)'
 			},
-			_accordionOpen: {
+			_allowChildrenRendering: {
 				type: Boolean,
 				value: false
 			}
@@ -346,8 +346,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._isOptionalModule();
 	}
 
-	getSubEntities(entity, accordionOpen) {
-		return accordionOpen && entity && entity.getSubEntities()
+	getSubEntities(entity, allowChildrenRendering) {
+		return allowChildrenRendering && entity && entity.getSubEntities()
 			.filter(subEntity => (subEntity.hasClass('sequenced-activity') && subEntity.hasClass('available')) || (subEntity.href && subEntity.hasClass('sequence-description')))
 			.map(this._getHref);
 	}
@@ -379,7 +379,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 	}
 
 	_onHeaderClicked() {
-		this._accordionOpen = this._isAccordionOpen();
+		this._allowChildrenRendering = true;
 	}
 
 	childIsActiveEvent() {


### PR DESCRIPTION
We don't need extra network calls being made from child components of modules before the module's open. After it's open those children can stay in the DOM, no need to re-render them each time the accordion opens/closes