### PR TITLE
Don't render a module's children unless it is visible. (Lazy Loading)

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -294,6 +294,10 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		};
 	}
 
+	static get observers() {
+		return ['_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded)'];
+	}
+
 	_accordionCollapseClass(focusWithin) {
 		return this._focusWithinClass(focusWithin);
 	}
@@ -423,8 +427,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		this._moduleWasExpanded = true;
 	}
 
-	_getShowModuleChildren() {
-		return this._moduleStartOpen || this._moduleWasExpanded;
+	_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded) {
+		return _moduleStartOpen || _moduleWasExpanded;
 	}
 
 	childIsActiveEvent() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -207,15 +207,17 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				<div id ="startDate">[[startDate]]</div>
 			</div>
 			<ol>
-				<template is="dom-repeat" items="[[subEntities]]" as="childLink">
-					<li on-click="_onActivityClicked" class$="[[_padOnActivity(childLink)]]">
-						<template is="dom-if" if="[[_isActivity(childLink)]]">
-							<d2l-activity-link last-module$="[[lastModule]]" is-sidebar$="[[isSidebar]]" href="[[childLink.href]]" token="[[token]]" current-activity="{{currentActivity}}" on-sequencenavigator-d2l-activity-link-current-activity="childIsActiveEvent"></d2l-activity-link>
-						</template>
-						<template is="dom-if" if="[[!_isActivity(childLink)]]">
-							<d2l-inner-module href="[[childLink.href]]" token="[[token]]" current-activity="{{currentActivity}}" on-sequencenavigator-d2l-inner-module-current-activity="childIsActiveEvent"></d2l-inner-module>
-						</template>
-					</li>
+				<template is="dom-if" if="[[_allowChildrenRendering]]">
+					<template is="dom-repeat" items="[[subEntities]]" as="childLink">
+						<li on-click="_onActivityClicked" class$="[[_padOnActivity(childLink)]]">
+							<template is="dom-if" if="[[_isActivity(childLink)]]">
+								<d2l-activity-link last-module$="[[lastModule]]" is-sidebar$="[[isSidebar]]" href="[[childLink.href]]" token="[[token]]" current-activity="{{currentActivity}}" on-sequencenavigator-d2l-activity-link-current-activity="childIsActiveEvent"></d2l-activity-link>
+							</template>
+							<template is="dom-if" if="[[!_isActivity(childLink)]]">
+								<d2l-inner-module href="[[childLink.href]]" token="[[token]]" current-activity="{{currentActivity}}" on-sequencenavigator-d2l-inner-module-current-activity="childIsActiveEvent"></d2l-inner-module>
+							</template>
+						</li>
+					</template>
 				</template>
 			</ol>
 		</d2l-labs-accordion-collapse>

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -176,7 +176,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		</style>
 
 		<d2l-labs-accordion-collapse no-icons="" flex="">
-			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
+			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" on-click="_onHeaderClicked" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>
 				<div class="border"></div>
 				<div class="module-header">
@@ -238,7 +238,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			subEntities: {
 				type: Array,
-				computed: 'getSubEntities(entity)'
+				computed: 'getSubEntities(entity, _accordionOpen)'
 			},
 			hasChildren: {
 				type: Boolean,
@@ -273,6 +273,10 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			_hideModuleDescription: {
 				type: Boolean,
 				computed: '_getHideModuleDescription(entity)'
+			},
+			_accordionOpen: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}
@@ -283,11 +287,13 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 	connectedCallback() {
 		super.connectedCallback();
+		this.addEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateHeaderClass);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
+		this.removeEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateHeaderClass);
 	}
 
@@ -340,8 +346,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._isOptionalModule();
 	}
 
-	getSubEntities(entity) {
-		return entity && entity.getSubEntities()
+	getSubEntities(entity, accordionOpen) {
+		return accordionOpen && entity && entity.getSubEntities()
 			.filter(subEntity => (subEntity.hasClass('sequenced-activity') && subEntity.hasClass('available')) || (subEntity.href && subEntity.hasClass('sequence-description')))
 			.map(this._getHref);
 	}
@@ -370,6 +376,10 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		if (childLink.class.includes('sequenced-activity') && this.currentActivity !== childLink.href) {
 			this.currentActivity = childLink.href;
 		}
+	}
+
+	_onHeaderClicked() {
+		this._accordionOpen = this._isAccordionOpen();
 	}
 
 	childIsActiveEvent() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -176,7 +176,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		</style>
 
 		<d2l-labs-accordion-collapse no-icons="" flex="">
-			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" on-click="_onHeaderClicked" is-sidebar$="[[isSidebar]]">
+			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>
 				<div class="border"></div>
 				<div class="module-header">
@@ -238,7 +238,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			subEntities: {
 				type: Array,
-				computed: 'getSubEntities(entity, _accordionOpen)'
+				computed: 'getSubEntities(entity, _allowChildrenRendering)'
 			},
 			hasChildren: {
 				type: Boolean,
@@ -274,7 +274,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				type: Boolean,
 				computed: '_getHideModuleDescription(entity)'
 			},
-			_accordionOpen: {
+			_allowChildrenRendering: {
 				type: Boolean,
 				value: false
 			}
@@ -346,8 +346,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._isOptionalModule();
 	}
 
-	getSubEntities(entity, accordionOpen) {
-		return accordionOpen && entity && entity.getSubEntities()
+	getSubEntities(entity, allowChildrenRendering) {
+		return allowChildrenRendering && entity && entity.getSubEntities()
 			.filter(subEntity => (subEntity.hasClass('sequenced-activity') && subEntity.hasClass('available')) || (subEntity.href && subEntity.hasClass('sequence-description')))
 			.map(this._getHref);
 	}
@@ -379,7 +379,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 	}
 
 	_onHeaderClicked() {
-		this._accordionOpen = this._isAccordionOpen();
+		this._allowChildrenRendering = true;
 	}
 
 	childIsActiveEvent() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -388,9 +388,12 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		}
 
 		const lastViewedParentHref = _lastViewedContentObjectEntity.getLinkByRel('up').href;
-		const thisHref = this.entity && this.entity.getLinkByRel('self').href;
 
-		return lastViewedParentHref === thisHref || subEntities.some((s) => s.href === lastViewedParentHref);
+		const isCurrentModuleLastViewedContentObject = _lastViewedContentObjectEntity.getLinkByRel('self').href === this.href;
+		const isDirectChildOfCurrentModule = lastViewedParentHref === this.href;
+		const isChildOfSubModule = subEntities.some((s) => s.href === lastViewedParentHref);
+
+		return isCurrentModuleLastViewedContentObject || isDirectChildOfCurrentModule || isChildOfSubModule;
 	}
 
 	_padOnActivity(childLink) {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -241,7 +241,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			subEntities: {
 				type: Array,
-				computed: 'getSubEntities(entity, _allowChildrenRendering)'
+				computed: 'getSubEntities(entity)'
 			},
 			hasChildren: {
 				type: Boolean,
@@ -363,8 +363,8 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._isOptionalModule();
 	}
 
-	getSubEntities(entity, allowChildrenRendering) {
-		return allowChildrenRendering && entity && entity.getSubEntities()
+	getSubEntities(entity) {
+		return entity && entity.getSubEntities()
 			.filter(subEntity => (subEntity.hasClass('sequenced-activity') && subEntity.hasClass('available')) || (subEntity.href && subEntity.hasClass('sequence-description')))
 			.map(this._getHref);
 	}
@@ -391,7 +391,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 		const isCurrentModuleLastViewedContentObject = _lastViewedContentObjectEntity.getLinkByRel('self').href === this.href;
 		const isDirectChildOfCurrentModule = lastViewedParentHref === this.href;
-		const isChildOfSubModule = subEntities && subEntities.some((s) => s.href === lastViewedParentHref);
+		const isChildOfSubModule = subEntities.some((s) => s.href === lastViewedParentHref);
 
 		return isCurrentModuleLastViewedContentObject || isDirectChildOfCurrentModule || isChildOfSubModule;
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -277,7 +277,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			_allowChildrenRendering: {
 				type: Boolean,
-				value: '_getAllowChildrenRendering(entity, subEntities, _currentActivityEntity)'
+				computed: '_getAllowChildrenRendering(entity, subEntities, _currentActivityEntity)'
 			},
 			_currentActivityEntity: {
 				type: Object

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -377,7 +377,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			return false;
 		}
 
-		const lastViewedParentHref = _lastViewedContentObjectEntity.getLinkByRel('up');
+		const lastViewedParentHref = _lastViewedContentObjectEntity.getLinkByRel('up').href;
 		const thisHref = this.entity && this.entity.getLinkByRel('self').href;
 
 		// eslint-disable-next-line

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -391,7 +391,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 		const isCurrentModuleLastViewedContentObject = _lastViewedContentObjectEntity.getLinkByRel('self').href === this.href;
 		const isDirectChildOfCurrentModule = lastViewedParentHref === this.href;
-		const isChildOfSubModule = subEntities.some((s) => s.href === lastViewedParentHref);
+		const isChildOfSubModule = subEntities && subEntities.some((s) => s.href === lastViewedParentHref);
 
 		return isCurrentModuleLastViewedContentObject || isDirectChildOfCurrentModule || isChildOfSubModule;
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -390,7 +390,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			// eslint-disable-next-line
 			console.log(`=== current activity is directly under outer module: ${thisHref}`);
 			return true;
-		} else if (subEntities.some((s) => s === lastViewedParentHref)) {
+		} else if (subEntities.some((s) => s.href === lastViewedParentHref)) {
 			// current activity is a child of one of the inner modules
 			// eslint-disable-next-line
 			console.log('--- current activity is under inner module');

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -207,7 +207,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				<div id ="startDate">[[startDate]]</div>
 			</div>
 			<ol>
-				<template is="dom-if" if="[[_allowChildrenRendering]]">
+				<template is="dom-if" if="[[_getShowModuleChildren()]]">
 					<template is="dom-repeat" items="[[subEntities]]" as="childLink">
 						<li on-click="_onActivityClicked" class$="[[_padOnActivity(childLink)]]">
 							<template is="dom-if" if="[[_isActivity(childLink)]]">
@@ -277,9 +277,13 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				type: Boolean,
 				computed: '_getHideModuleDescription(entity)'
 			},
-			_allowChildrenRendering: {
+			_moduleStartOpen: {
 				type: Boolean,
-				computed: '_getAllowChildrenRendering(entity, subEntities, _lastViewedContentObjectEntity)'
+				computed: '_getModuleStartOpen(entity, subEntities, _lastViewedContentObjectEntity)'
+			},
+			_moduleWasExpanded: {
+				type: Boolean,
+				value:false
 			},
 			lastViewedContentObject: {
 				type: String
@@ -374,7 +378,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._getTrueClass(focusWithin, selected);
 	}
 
-	_getAllowChildrenRendering(entity, subEntities, _lastViewedContentObjectEntity) {
+	_getModuleStartOpen(entity, subEntities, _lastViewedContentObjectEntity) {
 		if (!entity || !_lastViewedContentObjectEntity) {
 			return false;
 		}
@@ -416,7 +420,11 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 	}
 
 	_onHeaderClicked() {
-		this._allowChildrenRendering = true;
+		this._moduleWasExpanded = true;
+	}
+
+	_getShowModuleChildren() {
+		return this._moduleStartOpen || this._moduleWasExpanded;
 	}
 
 	childIsActiveEvent() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -207,7 +207,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 				<div id ="startDate">[[startDate]]</div>
 			</div>
 			<ol>
-				<template is="dom-if" if="[[_getShowModuleChildren()]]">
+				<template is="dom-if" if="[[_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded)]]">
 					<template is="dom-repeat" items="[[subEntities]]" as="childLink">
 						<li on-click="_onActivityClicked" class$="[[_padOnActivity(childLink)]]">
 							<template is="dom-if" if="[[_isActivity(childLink)]]">

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -175,7 +175,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 		</style>
 
-		<siren-entity href="[[currentActivity]]" token="[[token]]" entity="{{_currentActivityEntity}}"></siren-entity>
+		<siren-entity href="[[lastViewedContentObject]]" token="[[token]]" entity="{{_lastViewedContentObjectEntity}}"></siren-entity>
 		<d2l-labs-accordion-collapse no-icons="" flex="">
 			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>
@@ -277,9 +277,12 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 			},
 			_allowChildrenRendering: {
 				type: Boolean,
-				computed: '_getAllowChildrenRendering(entity, subEntities, _currentActivityEntity)'
+				computed: '_getAllowChildrenRendering(entity, subEntities, _lastViewedContentObjectEntity)'
 			},
-			_currentActivityEntity: {
+			lastViewedContentObject: {
+				type: String
+			},
+			_lastViewedContentObjectEntity: {
 				type: Object
 			}
 		};
@@ -369,28 +372,25 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 		return this._getTrueClass(focusWithin, selected);
 	}
 
-	_getAllowChildrenRendering(entity, subEntities, _currentActivityEntity) {
-		// eslint-disable-next-line
-		console.log({entity, subEntities, _currentActivityEntity});
-
-		if (!entity || !_currentActivityEntity) {
+	_getAllowChildrenRendering(entity, subEntities, _lastViewedContentObjectEntity) {
+		if (!entity || !_lastViewedContentObjectEntity) {
 			return false;
 		}
 
-		const currentActivityParentHref = _currentActivityEntity.getLinkByRel('up');
+		const lastViewedParentHref = _lastViewedContentObjectEntity.getLinkByRel('up');
 		const thisHref = this.entity && this.entity.getLinkByRel('self').href;
 
 		// eslint-disable-next-line
-		console.log({currentActivityParentHref});
+		console.log({entity, subEntities, _lastViewedContentObjectEntity, currentActivityParentHref: lastViewedParentHref});
 
 		// If the parentHref is equal to THIS href, or equal to ANY of the subEntity hrefs, expand return true
 
 		// current activity is a direct child of this outer module
-		if (currentActivityParentHref === thisHref) {
+		if (lastViewedParentHref === thisHref) {
 			// eslint-disable-next-line
 			console.log(`=== current activity is directly under outer module: ${thisHref}`);
 			return true;
-		} else if (subEntities.some((s) => s === currentActivityParentHref)) {
+		} else if (subEntities.some((s) => s === lastViewedParentHref)) {
 			// current activity is a child of one of the inner modules
 			// eslint-disable-next-line
 			console.log('--- current activity is under inner module');

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -175,7 +175,7 @@ class D2LSequenceLauncherModule extends ASVFocusWithinMixin(PolymerASVLaunchMixi
 
 		</style>
 
-		<siren-entity href="[[href]]" token="[[token]]" entity="{{_currentActivityEntity}}"></siren-entity>
+		<siren-entity href="[[currentActivity]]" token="[[token]]" entity="{{_currentActivityEntity}}"></siren-entity>
 		<d2l-labs-accordion-collapse no-icons="" flex="">
 			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity, focusWithin)]] [[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription, isSidebar)]]" is-sidebar$="[[isSidebar]]">
 				<div class="bkgd"></div>

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -51,7 +51,7 @@ PolymerElement
 			outline: none;
 		}
 
-		#launcher-unit-content {
+		#sidebarContent {
 			position: relative;
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -72,13 +72,13 @@ PolymerElement
 		</style>
 		<siren-entity href="[[rootHref]]" token="[[token]]" entity="{{_lessonEntity}}"></siren-entity>
 		<slot name="lesson-header"></slot>
-		<d2l-labs-accordion auto-close="" class="module-content" id="launcher-unit-content">
+		<d2l-labs-accordion auto-close="" class="module-content" id="sidebarContent" on-scroll="onSidebarScroll">
 			<ol class="module-item-list">
 				<template is="dom-repeat" items="[[subEntities]]" as="childLink">
 					<template is="dom-if" if="[[childLink.href]]">
 						<li>
 							<template is="dom-if" if="[[!_isActivity(childLink)]]">
-								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" last-module="[[isLast(subEntities, index)]]" last-viewed-content-object="[[lastViewedContentObject]]"></d2l-sequence-launcher-module>
+								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" is-sidebar="[[isSidebar()]]" last-module="[[isLast(subEntities, index)]]" last-viewed-content-object="[[lastViewedContentObject]]"></d2l-sequence-launcher-module>
 							</template>
 							<template is="dom-if" if="[[_isActivity(childLink)]]">
 								<d2l-activity-link href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" before-module$="[[isBeforeModule(subEntities, index)]]"></d2l-activity-link>
@@ -153,6 +153,24 @@ PolymerElement
 		return entity && entity.getLinkByRel && entity.getLinkByRel('self') || entity || '';
 	}
 
+	onSidebarScroll() {
+		const sidebarHeader = this.getSideBarHeader();
+		if (this.$.sidebarContent.scrollTop === 0) {
+			if (sidebarHeader && sidebarHeader.classList && sidebarHeader.classList.contains('shadowed')) {
+				sidebarHeader.classList.remove('shadowed');
+			}
+		} else {
+			if (sidebarHeader && sidebarHeader.classList && !sidebarHeader.classList.contains('shadowed')) {
+				sidebarHeader.classList.add('shadowed');
+			}
+		}
+	}
+
+	getSideBarHeader() {
+		const sidebarHeaderSlot = this.shadowRoot.querySelector('slot');
+		return sidebarHeaderSlot.assignedNodes()[0].querySelector('d2l-lesson-header#sidebarHeader');
+	}
+
 	isBeforeModule(subEntities, index) {
 		if (index < subEntities.length - 1) {
 			if (!this._isActivity(subEntities[index + 1])) {
@@ -164,6 +182,9 @@ PolymerElement
 
 	isLast(entities, index) {
 		return entities.length <= index + 1;
+	}
+	isSidebar() {
+		return this.role === 'navigation';
 	}
 }
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -51,7 +51,7 @@ PolymerElement
 			outline: none;
 		}
 
-		#sidebarContent {
+		#launcher-unit-content {
 			position: relative;
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -72,13 +72,13 @@ PolymerElement
 		</style>
 		<siren-entity href="[[rootHref]]" token="[[token]]" entity="{{_lessonEntity}}"></siren-entity>
 		<slot name="lesson-header"></slot>
-		<d2l-labs-accordion auto-close="" class="module-content" id="sidebarContent" on-scroll="onSidebarScroll">
+		<d2l-labs-accordion auto-close="" class="module-content" id="launcher-unit-content">
 			<ol class="module-item-list">
 				<template is="dom-repeat" items="[[subEntities]]" as="childLink">
 					<template is="dom-if" if="[[childLink.href]]">
 						<li>
 							<template is="dom-if" if="[[!_isActivity(childLink)]]">
-								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" is-sidebar="[[isSidebar()]]" last-module="[[isLast(subEntities, index)]]" last-viewed-content-object="[[lastViewedContentObject]]"></d2l-sequence-launcher-module>
+								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" last-module="[[isLast(subEntities, index)]]" last-viewed-content-object="[[lastViewedContentObject]]"></d2l-sequence-launcher-module>
 							</template>
 							<template is="dom-if" if="[[_isActivity(childLink)]]">
 								<d2l-activity-link href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" before-module$="[[isBeforeModule(subEntities, index)]]"></d2l-activity-link>
@@ -153,25 +153,6 @@ PolymerElement
 		return entity && entity.getLinkByRel && entity.getLinkByRel('self') || entity || '';
 	}
 
-	onSidebarScroll() {
-		const sidebarHeader = this.getSideBarHeader();
-		if (this.$.sidebarContent.scrollTop === 0) {
-			if (sidebarHeader && sidebarHeader.classList && sidebarHeader.classList.contains('shadowed')) {
-				sidebarHeader.classList.remove('shadowed');
-			}
-		} else {
-			if (sidebarHeader && sidebarHeader.classList && !sidebarHeader.classList.contains('shadowed')) {
-				sidebarHeader.classList.add('shadowed');
-			}
-		}
-	}
-
-	getSideBarHeader() {
-		const sidebarHeaderSlot = this.shadowRoot.querySelector('slot');
-		const sidebarHeader = sidebarHeaderSlot.assignedNodes()[0].querySelector('d2l-lesson-header#sidebarHeader');
-		return sidebarHeader;
-	}
-
 	isBeforeModule(subEntities, index) {
 		if (index < subEntities.length - 1) {
 			if (!this._isActivity(subEntities[index + 1])) {
@@ -182,18 +163,7 @@ PolymerElement
 	}
 
 	isLast(entities, index) {
-		if (entities.length <= index + 1) {
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
-	isSidebar() {
-		if (this.role === 'navigation') {
-			return true;
-		}
-		return false;
+		return entities.length <= index + 1;
 	}
 }
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -78,7 +78,7 @@ PolymerElement
 					<template is="dom-if" if="[[childLink.href]]">
 						<li>
 							<template is="dom-if" if="[[!_isActivity(childLink)]]">
-								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" is-sidebar="[[isSidebar()]]" last-module="[[isLast(subEntities, index)]]"></d2l-sequence-launcher-module>
+								<d2l-sequence-launcher-module href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" is-sidebar="[[isSidebar()]]" last-module="[[isLast(subEntities, index)]]" last-viewed-content-object="[[lastViewedContentObject]]"></d2l-sequence-launcher-module>
 							</template>
 							<template is="dom-if" if="[[_isActivity(childLink)]]">
 								<d2l-activity-link href="[[childLink.href]]" token="[[token]]" current-activity="{{href}}" before-module$="[[isBeforeModule(subEntities, index)]]"></d2l-activity-link>
@@ -116,6 +116,9 @@ PolymerElement
 			},
 			_lessonEntity:{
 				type: Object
+			},
+			lastViewedContentObject: {
+				type: String
 			}
 		};
 	}

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -272,7 +272,7 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 			},
 			startDate: {
 				type: String,
-				computed: 'getFormatedDate(entity)'
+				computed: 'getFormattedDate(entity)'
 			},
 			_hideModuleDescription: {
 				type: Boolean,
@@ -416,7 +416,7 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 		}
 	}
 
-	getFormatedDate(entity) {
+	getFormattedDate(entity) {
 
 		const currentDate = new Date();
 		let startDate;


### PR DESCRIPTION
sequence lawn chair pr: https://github.com/Brightspace/sequence-launcher-fra/pull/103

This pr provides lazy loading at the Lesson / Module level. How it works is that it will wrap it's children in a `dom-if` whose condition is determined by 2 things:
1. If the last accessed module is inside it (checks 2 levels)
2. If the user clicks the header

Note for 1. is that the accordion for the module will start visibly closed even though I can see it is correctly evaluating to true. So those elements are being fetched/rendered but you still need to click to see them. (For now, implemented in a future pr)

This pr does not have any skeletons or anything, so those topics will pop-in when expanded much like the lazy loading for the unit that was done a while ago.

I also did some small minor cleanup.