### PR TITLE
Lazy Load + Collapse state for inner/sub modules

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -197,6 +197,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 									current-activity="{{currentActivity}}"
 									on-sequencenavigator-d2l-inner-module-current-activity="childIsActiveEvent"
 									on-d2l-content-entity-loaded="checkIfChildrenDoneLoading"
+									last-viewed-content-object-entity="[[_lastViewedContentObjectEntity]]"
 								></d2l-inner-module>
 							</template>
 						</li>
@@ -287,7 +288,8 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				computed: '_getLaunchModuleHref(entity)'
 			},
 			_iconName: {
-				type: String
+				type: String,
+				value: 'tier1:arrow-expand-small'
 			}
 		};
 	}

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -347,7 +347,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	checkIfChildrenDoneLoading(contentLoadedEvent) {
 		const childHref = contentLoadedEvent.detail.href;
 
-		if (!this._childrenLoadingTracker) {
+		if (!this._childrenLoadingTracker || !this._childrenLoading) {
 			return;
 		}
 
@@ -356,7 +356,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			contentLoadedEvent.stopPropagation();
 		}
 
-		if (this._childrenLoading && !Object.values(this._childrenLoadingTracker).some(loaded => !loaded)) {
+		if (!Object.values(this._childrenLoadingTracker).some(loaded => !loaded)) {
 			this._childrenLoading = false;
 			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));
 		}

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -48,14 +48,18 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				display: flex;
 			}
 
-			d2l-icon {
-				padding-right: 15px;
-				color: var(--d2l-color-celestine);
-			}
-
 			#module-header.hide-description,
 			#module-header.hide-description > a {
 				cursor: default;
+			}
+
+			.header-left > d2l-icon {
+				padding-right: 15px;
+				color: var(--d2l-inner-module-text-color);
+			}
+
+			.header-right {
+				color: var(--d2l-outer-module-text-color);
 			}
 
 			ol {
@@ -110,11 +114,16 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		<div id="skeleton"></div>
 		<div id="header-container" class$="[[isEmpty(subEntities)]]">
 			<div id="module-header" class$="[[[[_getHideDescriptionClass(_hideDescription)]]" on-click="_onHeaderClicked">
-				<div>
+				<div class="header-left">
 					<d2l-icon icon="tier1:folder"></d2l-icon>
 					<span class="module-title">[[entity.properties.title]]</span>
 				</div>
-				<d2l-icon id="expand-icon" icon="tier1:arrow-expand-small"></d2l-icon>
+				<div class="header-right">
+					<span class="countStatus" aria-hidden="true">
+						[[localize('sequenceNavigator.countStatus', 'completed', completionCompleted, 'total', completionTotal)]]
+					</span>
+					<d2l-icon id="expand-icon" icon="tier1:arrow-expand-small"></d2l-icon>
+				</div>
 			</div>
 		</div>
 		<ol>

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -241,9 +241,15 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 
 		const isCurrentModuleLastViewedContentObject = lastViewedContentObjectEntity.getLinkByRel('self').href === this.href;
 		const isDirectChildOfCurrentModule = lastViewedParentHref === this.href;
-		const isChildOfSubModule = subEntities.some((s) => s.href === lastViewedParentHref);
+		// const isChildOfSubModule = subEntities.some((s) => s.href === lastViewedParentHref);
 
-		return isCurrentModuleLastViewedContentObject || isDirectChildOfCurrentModule || isChildOfSubModule;
+		const startOpen = isCurrentModuleLastViewedContentObject || isDirectChildOfCurrentModule;
+
+		if (!startOpen) {
+			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));
+		}
+
+		return startOpen;
 	}
 
 	_updateCollapseIconName() {
@@ -347,6 +353,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		}, {});
 	}
 
+	// TODO: modify this to only check if self is loaded if closed, children if open
 	checkIfChildrenDoneLoading(contentLoadedEvent) {
 		const childHref = contentLoadedEvent.detail.href;
 


### PR DESCRIPTION
This pr adds lazy loading for the topics inside submodules. On the launcher, submods will be collapsed just like regular modules unless your last-viewed topic is that submodule itself, or a topic inside it.

![image](https://user-images.githubusercontent.com/14796305/78736654-4eb44d00-7913-11ea-949b-0350b9ed3a65.png)
