### PR TITLE
Fix the launch module button

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -419,7 +419,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 	}
 
 	_onLaunchUnitButtonClick() {
-		console.log('wewewew');
 		this.currentActivity = this.entity.getLinkByRel('self').href;
 		this._contentObjectClick();
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -167,7 +167,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 					aria-label$="[[localize('sequenceNavigator.launchModule')]]"
 					text="[[localize('sequenceNavigator.launchModule')]]"
 					icon="tier1:move-to"
-					on-click="_onLaunchUnitButtonClick"
+					on-click="_onLaunchModuleButtonClick"
 				>
 				</d2l-button-subtle>
 			</div>
@@ -418,7 +418,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		this._moduleWasExpanded = true;
 	}
 
-	_onLaunchUnitButtonClick() {
+	_onLaunchModuleButtonClick() {
 		this.currentActivity = this.entity.getLinkByRel('self').href;
 		this._contentObjectClick();
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -163,14 +163,13 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				<div id ="startDate">[[startDate]]</div>
 			</div>
 			<div id="launch-module-container">
-				<a href="[[_launchModuleHref]]">
-					<d2l-button-subtle
-						aria-label$="[[localize('sequenceNavigator.launchModule')]]"
-						text="[[localize('sequenceNavigator.launchModule')]]"
-						icon="tier1:move-to"
-					>
-					</d2l-button-subtle>
-				</a>
+				<d2l-button-subtle
+					aria-label$="[[localize('sequenceNavigator.launchModule')]]"
+					text="[[localize('sequenceNavigator.launchModule')]]"
+					icon="tier1:move-to"
+					on-click="_onLaunchUnitButtonClick"
+				>
+				</d2l-button-subtle>
 			</div>
 			<ol>
 				<template is="dom-if" if="[[_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded)]]">
@@ -282,10 +281,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				type: Object,
 				computed: '_setUpChildrenLoadingTracker(subEntities)'
 			},
-			_launchModuleHref: {
-				type: String,
-				computed: '_getLaunchModuleHref(entity)'
-			},
 			_iconName: {
 				type: String
 			}
@@ -344,20 +339,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		const nextSibling = subEntities[index + 1];
 
 		return this._isActivity(nextSibling);
-	}
-
-	// TODO: this function needs work
-	_getLaunchModuleHref(entity) {
-		if (!entity) {
-			return '';
-		}
-
-		if (entity.getLinkByRel('alternate')) {
-			return entity.getLinkByRel('alternate').href;
-		}
-
-		// TODO: this isn't working... getting 401 unauthorized
-		return entity.getLinkByRel('self').href;
 	}
 
 	_showCount() {
@@ -435,6 +416,12 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 
 	_onHeaderClicked() {
 		this._moduleWasExpanded = true;
+	}
+
+	_onLaunchUnitButtonClick() {
+		console.log('wewewew');
+		this.currentActivity = this.entity.getLinkByRel('self').href;
+		this._contentObjectClick();
 	}
 
 	_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded) {


### PR DESCRIPTION
This pr fixes the launch module button by reverting the behaviour back to what it was before. It didn't like putting it as an href on an anchor tag because it would get confused about staying on the `/sequenceLauncher/` route and not going to the `/sequenceViewer/` route.

Also there were no "changes" picked up, but the collapse/expand arrows are aligned now because core was updated.

![image](https://user-images.githubusercontent.com/14796305/78819238-86ff6e00-799b-11ea-8c5a-d35a4da97f88.png)
