### PR TITLE
Redesign expanded units

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -45,7 +45,6 @@ PolymerElement
 
 			.module-content {
 				height: calc( 100% - 203px );
-				border-top: 1px solid var(--d2l-color-mica);
 			}
 
 			#sidebarContent {


### PR DESCRIPTION
The design for expanded units changed. Originally the design had them with a grey background and borders to separate things. This matches it to the new design, which is always blue with no underlines.

launcher pr: https://github.com/Brightspace/sequence-launcher-fra/pull/112

![image](https://user-images.githubusercontent.com/14796305/79139002-21382b00-7d7b-11ea-9a93-4acf47f9ea87.png)
