### PR TITLE
Break words onto new lines

### DIFF
--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -84,7 +84,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			}
 
 			.d2l-activity-link-title {
-				word-wrap: break-word;
+				word-break: break-word;
 				display: flex;
 				flex: 1;
 				flex-direction: column;


### PR DESCRIPTION
Things changed and `word-wrap` no longer did what it was supposed to do, so `word-break` was needed.

`word-break` breaks words against the width of the parent container, and since this stuff converted to using flexbox, this was more appropriate.

https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

![image](https://user-images.githubusercontent.com/14796305/80008722-bdee7d00-848d-11ea-93ac-1b707fcc8982.png)
