### PR TITLE
DE38773 completion entities don't count for unit early load

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -251,7 +251,11 @@ PolymerElement
 	}
 
 	_checkForEarlyLoadEvent(entity, subEntities) {
-		if (entity && subEntities && subEntities.length <= 0) {
+		if (entity &&
+			subEntities && (
+			subEntities.length <= 0 ||
+			subEntities[0].rel.includes('item'))
+		) {
 			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));
 		}
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -253,7 +253,7 @@ PolymerElement
 	_checkForEarlyLoadEvent(entity, subEntities) {
 		if (entity &&
 			subEntities && (
-			subEntities.length <= 0 ||
+			subEntities.length <== 0 ||
 			subEntities.find(({ rel }) => rel && rel.includes('item')))
 		) {
 			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -254,7 +254,7 @@ PolymerElement
 		if (entity &&
 			subEntities && (
 			subEntities.length <= 0 ||
-			subEntities[0].rel.includes('item'))
+			subEntities.find(({ rel }) => rel && rel.includes('item')))
 		) {
 			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));
 		}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -253,7 +253,7 @@ PolymerElement
 	_checkForEarlyLoadEvent(entity, subEntities) {
 		if (entity &&
 			subEntities && (
-			subEntities.length <== 0 ||
+			subEntities.length <= 0 ||
 			subEntities.find(({ rel }) => rel && rel.includes('item')))
 		) {
 			this.dispatchEvent(new CustomEvent('d2l-content-entity-loaded', {detail: { href: this.href}}));


### PR DESCRIPTION
Previously, for some reason, if there were no children for a given unit its only subentity would be a completion entity. Now that's accounted for when checking whether or not a unit should fire off an early loading event when it has no children.