### PR TITLE
DE34552 end of lesson activities not focusing via keyboard

### DIFF
--- a/d2l-sequence-navigator/d2l-eol-activity-link.js
+++ b/d2l-sequence-navigator/d2l-eol-activity-link.js
@@ -156,6 +156,11 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 	}
 	static get properties() {
 		return {
+			class: {
+				type: String,
+				reflectToAttribute: true,
+				computed:'_focusWithinClass(focusWithin)'
+			},
 			hasIcon: {
 				type: Boolean,
 				computed: '_hasIcon(entity)'

--- a/d2l-sequence-navigator/d2l-eol-activity-link.js
+++ b/d2l-sequence-navigator/d2l-eol-activity-link.js
@@ -154,13 +154,13 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 	static get is() {
 		return 'd2l-eol-activity-link';
 	}
+
+	static get observers() {
+		return ['_onFocusWithinChange(focusWithin)'];
+	}
+
 	static get properties() {
 		return {
-			class: {
-				type: String,
-				reflectToAttribute: true,
-				computed:'_focusWithinClass(focusWithin)'
-			},
 			hasIcon: {
 				type: Boolean,
 				computed: '_hasIcon(entity)'
@@ -194,6 +194,14 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 	_getIconSetKey(entity) {
 		const tierClass = 'tier1';
 		return (entity.getSubEntityByClass(tierClass)).properties.iconSetKey;
+	}
+
+	_onFocusWithinChange(focusWithin) {
+		if (focusWithin) {
+			this.classList.add('d2l-asv-focus-within');
+		} else {
+			this.classList.remove('d2l-asv-focus-within');
+		}
 	}
 }
 customElements.define(D2LEolActivityLink.is, D2LEolActivityLink);


### PR DESCRIPTION
While the `focusWithin` property was being updated properly in `ASVFocusWithinMixin` it was not setting the class on the `d2l-eol-activity-link` component. This was fixed by adding the class property to the component and reflecting it as an attribute to add the class on focus.