### PR TITLE
imcdonald/de38770 dynamic width of eol activity links to account for mobile devices

### DIFF
--- a/components/d2l-sequences-content-eol-main.js
+++ b/components/d2l-sequences-content-eol-main.js
@@ -43,7 +43,9 @@ export class D2LSequencesContentEoLMain extends D2L.Polymer.Mixins.Sequences.Ret
 				margin: auto!important;
 			}
 			@media (max-width:550px) {
-				d2l-missed-activity { width: 100%; }
+				d2l-missed-activity {
+					width: 100%;
+				}
 			}
 		</style>
 		<div class="content-eol-main-container">

--- a/components/d2l-sequences-content-eol-main.js
+++ b/components/d2l-sequences-content-eol-main.js
@@ -37,10 +37,13 @@ export class D2LSequencesContentEoLMain extends D2L.Polymer.Mixins.Sequences.Ret
 			.missed-count-text {
 				color: var(--d2l-color-celestine);
 			}
-			d2l-missed-activity{
+			d2l-missed-activity {
 				text-align: left;
 				width: 50%;
 				margin: auto!important;
+			}
+			@media (max-width:550px) {
+				d2l-missed-activity { width: 100%; }
 			}
 		</style>
 		<div class="content-eol-main-container">

--- a/demo/d2l-sequence-navigator/d2l-sequences-content-eol-main.html
+++ b/demo/d2l-sequence-navigator/d2l-sequences-content-eol-main.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en" style="font-size:20px; font-family: 'Lato', sans-serif;"
+	data-asv-css-vars='{"--d2l-asv-primary-color":"#990000","--d2l-asv-accent-color":"rgb(142,124,195)","--d2l-asv-text-color":"var(--d2l-color-ferrite)","--d2l-asv-selected-text-color":"var(--d2l-color-white)","--d2l-asv-hover-color":"rgba(142,124,195, 0.18)","--d2l-asv-border-color":"transparent"}'>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<title>content-eol-main demo</title>
+	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script type="module">
+		import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+		import '@polymer/iron-demo-helpers/demo-snippet';
+		import '../../components/d2l-sequences-content-eol-main.js';
+	</script>
+
+	<custom-style>
+		<style is="custom-style" include="demo-pages-shared-styles"></style>
+		<style>
+			html {
+				--d2l-asv-primary-color: #990000;
+				--d2l-asv-accent-color: rgb(142, 124, 195);
+				--d2l-asv-text-color: var(--d2l-color-ferrite);
+				--d2l-asv-selected-text-color: white;
+				--d2l-asv-hover-color: rgba(142, 124, 195, 0.18);
+				--d2l-asv-border-color: transparent;
+			}
+		</style>
+	</custom-style>
+	<custom-style include="d2l-typography">
+		<style is="custom-style" include="d2l-typography"></style>
+		<style>
+			.body {
+				@apply --d2l-typography;
+			}
+		</style>
+	</custom-style>
+	<style>
+		d2l-sequence-navigator {
+			--d2l-sequence-nav-padding: 30px;
+		}
+
+		.centered {
+			max-width: 800px !important;
+		}
+	</style>
+
+<body class="d2l-typography">
+	<div class="vertical-section-container centered">
+		<demo-snippet>
+			<template>
+				<h4>Sequences Content EOL Main Demo</h4>
+				<d2l-sequences-content-eol-main href="data/missed-activity.json" token="foo">
+				</d2l-sequences-content-eol-main>
+			</template>
+		</demo-snippet>
+	</div>
+</body>
+
+</html>

--- a/demo/d2l-sequence-navigator/d2l-sequences-content-eol-main.html
+++ b/demo/d2l-sequence-navigator/d2l-sequences-content-eol-main.html
@@ -34,11 +34,8 @@
 			}
 		</style>
 	</custom-style>
-	<style>
-		d2l-sequence-navigator {
-			--d2l-sequence-nav-padding: 30px;
-		}
 
+	<style>
 		.centered {
 			max-width: 800px !important;
 		}

--- a/demo/d2l-sequence-navigator/data/missed-activity.json
+++ b/demo/d2l-sequence-navigator/data/missed-activity.json
@@ -5,7 +5,8 @@
 	"class": [
 		"sequence",
 		"sequence-description",
-		"end-of-sequence"
+		"end-of-sequence",
+		"enhanced-end-of-sequence"
 	],
 	"links": [
 		{

--- a/demo/d2l-sequence-navigator/index.html
+++ b/demo/d2l-sequence-navigator/index.html
@@ -16,6 +16,7 @@
 		import '../../d2l-sequence-navigator/d2l-lesson-header.js';
 		import '../../d2l-sequence-navigator/d2l-missed-activity.js';
 		import '../../d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js';
+		import '../../components/d2l-sequences-content-eol-main.js';
 		window.D2L.Siren.WhitelistBehavior._testMode(true);
 	</script>
 
@@ -160,6 +161,13 @@
 				<h4>Singular Missed Activity Module</h4>
 				<d2l-missed-activity href="data/missed-activity1.json" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlYmIzMmNlLTQzMDQtNDg1YS04MDI5LTZkNjkxYWVjNTdkZCJ9.eyJ0ZW5hbnRpZCI6ImEyZjc2NzI4LTk0MjMtNDA5OC1iMWM4LTU1YmM4ZWVkMTI0MCIsInNjb3BlIjoiKjoqOioiLCJqdGkiOiJhM2Y3YmQzNS1iMWM1LTQzYmQtOTgwMi1iMTA0OWEzM2NhNjUiLCJpc3MiOiJodHRwczovL2FwaS5icmlnaHRzcGFjZS5jb20vYXV0aCIsImF1ZCI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoL3Rva2VuIiwiZXhwIjoxNTU3NzYxOTc4LCJuYmYiOjE1NTc3NTgzNzh9.juuVN6k9C94A9tlgiF5KLBOQEVSN7T_gOHjxZazi_deiNZ_-vYGl18WpswMT8y-BH5n3nye8Pv-zzXDHNJhNtQICOlMbyufCA2GYLKxbyeocqNQgHCKhJfu0oxBBEpTRATUc1qrUNBEoLPuT_ak53gqr-y9ZYb-_UWnW6xpgujDIdS4QvJOBxjQo-X_R54VTOstD_gc0s47EhsU8W_Y3XCHWB50tg2tMEch0J4KZXh0E9aKLDqcot22SXdlhkH8QWHjjUdHjAs9XxjGSJTHETz81ni-zXJ4YoFX-Ku-WTWWMmcaE_p37RmzoNS1hkNE7Dc1vFNbvuCBKbMghW8optg">
 				</d2l-missed-activity>
+			</template>
+		</demo-snippet>
+		<demo-snippet>
+			<template>
+				<h4>Sequences Content EOL Main</h4>
+				<d2l-sequences-content-eol-main href="data/missed-activity.json" token="foo">
+				</d2l-sequences-content-eol-main>
 			</template>
 		</demo-snippet>
 	</div>

--- a/demo/d2l-sequence-navigator/index.html
+++ b/demo/d2l-sequence-navigator/index.html
@@ -16,7 +16,6 @@
 		import '../../d2l-sequence-navigator/d2l-lesson-header.js';
 		import '../../d2l-sequence-navigator/d2l-missed-activity.js';
 		import '../../d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js';
-		import '../../components/d2l-sequences-content-eol-main.js';
 		window.D2L.Siren.WhitelistBehavior._testMode(true);
 	</script>
 
@@ -161,13 +160,6 @@
 				<h4>Singular Missed Activity Module</h4>
 				<d2l-missed-activity href="data/missed-activity1.json" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlYmIzMmNlLTQzMDQtNDg1YS04MDI5LTZkNjkxYWVjNTdkZCJ9.eyJ0ZW5hbnRpZCI6ImEyZjc2NzI4LTk0MjMtNDA5OC1iMWM4LTU1YmM4ZWVkMTI0MCIsInNjb3BlIjoiKjoqOioiLCJqdGkiOiJhM2Y3YmQzNS1iMWM1LTQzYmQtOTgwMi1iMTA0OWEzM2NhNjUiLCJpc3MiOiJodHRwczovL2FwaS5icmlnaHRzcGFjZS5jb20vYXV0aCIsImF1ZCI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoL3Rva2VuIiwiZXhwIjoxNTU3NzYxOTc4LCJuYmYiOjE1NTc3NTgzNzh9.juuVN6k9C94A9tlgiF5KLBOQEVSN7T_gOHjxZazi_deiNZ_-vYGl18WpswMT8y-BH5n3nye8Pv-zzXDHNJhNtQICOlMbyufCA2GYLKxbyeocqNQgHCKhJfu0oxBBEpTRATUc1qrUNBEoLPuT_ak53gqr-y9ZYb-_UWnW6xpgujDIdS4QvJOBxjQo-X_R54VTOstD_gc0s47EhsU8W_Y3XCHWB50tg2tMEch0J4KZXh0E9aKLDqcot22SXdlhkH8QWHjjUdHjAs9XxjGSJTHETz81ni-zXJ4YoFX-Ku-WTWWMmcaE_p37RmzoNS1hkNE7Dc1vFNbvuCBKbMghW8optg">
 				</d2l-missed-activity>
-			</template>
-		</demo-snippet>
-		<demo-snippet>
-			<template>
-				<h4>Sequences Content EOL Main</h4>
-				<d2l-sequences-content-eol-main href="data/missed-activity.json" token="foo">
-				</d2l-sequences-content-eol-main>
 			</template>
 		</demo-snippet>
 	</div>


### PR DESCRIPTION
Used media query to dynamically set width of content so it is easily visible on a mobile device.
Demo page for testing added to `demo/d2l-sequence-navigator/d2l-sequences-content-eol-main.html`. You can open dev tools and set device to try various display widths.
[Original Rally Ticket](https://rally1.rallydev.com/#/289692574792d/detail/defect/387156470440)

Before:
![before](https://user-images.githubusercontent.com/64804046/81420411-eaf18f80-911d-11ea-9a5b-d206a9807bee.PNG)

After:
![after](https://user-images.githubusercontent.com/64804046/81420451-f93fab80-911d-11ea-8edc-021553a80393.PNG)
