### PR TITLE
DE38701 header color issue when lesson/sub-folder part of module

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -21,7 +21,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 			:host {
 				display: block;
 				@apply --d2l-body-compact-text;
-				--d2l-outer-module-text-color: var(--d2l-asv-text-color);
+				--d2l-outer-module-text-color: var(--d2l-color-ferrite);
 			}
 
 			d2l-labs-accordion-collapse:focus {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -126,7 +126,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			}
 
 			d2l-completion-status {
-				color: var(--d2l-asv-text-color);
+				color: var(--d2l-color-ferrite);
 			}
 
 			@keyframes loadingShimmer {

--- a/d2l-sequence-navigator/d2l-eol-activity-link.js
+++ b/d2l-sequence-navigator/d2l-eol-activity-link.js
@@ -16,7 +16,7 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 		<style>
 			:host {
 				--d2l-activity-link-border-color: var(--d2l-activity-link-background-color);
-				--d2l-activity-link-text-color: var(--d2l-asv-text-color);
+				--d2l-activity-link-text-color: var(--d2l-color-ferrite);
 				--d2l-activity-link-opacity: 1;
 				--d2l-activity-link-backdrop-opacity: 0;
 				--d2l-left-icon-padding: 15px;
@@ -52,9 +52,9 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 			:host(:focus),
 			:host(:hover) {
 				--d2l-activity-link-background-color: var(--d2l-asv-hover-color);
-				--d2l-activity-link-subtext-color: var(--d2l-asv-text-color);
+				--d2l-activity-link-subtext-color: var(--d2l-color-ferrite);
 				--d2l-activity-link-border-color: rgba(0, 0, 0, 0.42);
-				--d2l-activity-link-text-color: var(--d2l-asv-text-color);
+				--d2l-activity-link-text-color: var(--d2l-color-ferrite);
 				--d2l-activity-link-opacity: 0.26;
 				--d2l-activity-link-backdrop-opacity: 1;
 			}

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -22,7 +22,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		return html`
 		<style>
 		:host {
-			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
+			--d2l-lesson-header-text-color: var(--d2l-color-ferrite);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-lesson-header-border-color: transparent;
 			--d2l-lesson-header-opacity: 1;

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -50,7 +50,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		:host(:hover:not(.hide-description)) {
 			--d2l-lesson-header-background-color: var(--d2l-asv-primary-color);
 			--d2l-lesson-header-border-color: rgba(0, 0, 0, 0.42);
-			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
+			--d2l-lesson-header-text-color: var(--d2l-color-ferrite);
 			--d2l-lesson-header-opacity: 0.26;
 		}
 
@@ -163,20 +163,20 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress,
 		:host(:hover:not(.hide-description)) progress.d2l-progress {
 			background-color: transparent;
-			border: 1px solid var(--d2l-asv-text-color);
+			border: 1px solid var(--d2l-color-ferrite);
 			box-shadow: none;
 		}
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-webkit-progress-value,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-webkit-progress-value {
-			background-color: var(--d2l-asv-text-color);
+			background-color: var(--d2l-color-ferrite);
 		}
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-moz-progress-bar,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-moz-progress-bar {
-			background-color: var(--d2l-asv-text-color);
+			background-color: var(--d2l-color-ferrite);
 		}
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-ms-fill,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-ms-fill {
-			background-color: var(--d2l-asv-text-color, #565a5c);
+			background-color: var(--d2l-color-ferrite, #565a5c);
 		}
 
 		div.title-container {

--- a/d2l-sequence-navigator/d2l-missed-activity.js
+++ b/d2l-sequence-navigator/d2l-missed-activity.js
@@ -16,7 +16,7 @@ class D2LMissedActivity extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Comple
 		return html`
 		<style>
 			:host {
-				--d2l-inner-module-text-color: var(--d2l-asv-text-color);
+				--d2l-inner-module-text-color: var(--d2l-color-ferrite);
 				--d2l-activity-link-padding: 10px 14px;
 				display: block;
 				cursor: pointer;

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -23,7 +23,7 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 				display: block;
 				@apply --d2l-body-compact-text;
 				width: 100%;
-				--d2l-outer-module-text-color: var(--d2l-asv-text-color);
+				--d2l-outer-module-text-color: var(--d2l-color-ferrite);
 				--d2l-outer-module-background-color: transparent;
 				--d2l-activity-link-padding: 10px 24px;
 				margin-top: -1px;

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -58,7 +58,7 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 			#header-container:hover:not(.hide-description) {
 				--d2l-outer-module-background-color: var(--d2l-asv-primary-color);
 				--d2l-outer-module-border-color: rgba(0, 0, 0, 0.42);
-				--d2l-outer-module-text-color: var(--d2l-asv-text-color);
+				--d2l-outer-module-text-color: var(--d2l-color-ferrite);
 				--d2l-outer-module-opacity: 0.26;
 			}
 
@@ -147,7 +147,7 @@ class D2LOuterModule extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completio
 			}
 
 			.d2l-asv-current .optionalStatus {
-				color: var(--d2l-asv-text-color);
+				color: var(--d2l-color-ferrite);
 			}
 
 			.d2l-asv-current:not(:hover) .optionalStatus {

--- a/d2l-sequence-navigator/d2l-sequence-end.js
+++ b/d2l-sequence-navigator/d2l-sequence-end.js
@@ -12,7 +12,7 @@ class D2LSequenceEnd extends ASVFocusWithinMixin(
 		return html`
 			<style>
 				#d2l-sequence-end-container {
-					--d2l-sequence-end-text-color: var(--d2l-asv-text-color);
+					--d2l-sequence-end-text-color: var(--d2l-color-ferrite);
 					--d2l-sequence-end-background-color: transparent;
 					--d2l-sequence-end-border-color: var(--d2l-sequence-end-background-color);
 					--d2l-sequence-end-opacity: 1;
@@ -41,7 +41,7 @@ class D2LSequenceEnd extends ASVFocusWithinMixin(
 				#d2l-sequence-end-container:hover {
 					--d2l-sequence-end-background-color: var(--d2l-asv-primary-color);
 					--d2l-sequence-end-border-color: rgba(0, 0, 0, 0.42);
-					--d2l-sequence-end-text-color: var(--d2l-asv-text-color);
+					--d2l-sequence-end-text-color: var(--d2l-color-ferrite);
 					--d2l-sequence-end-opacity: 0.26;
 					cursor: pointer;
 				}


### PR DESCRIPTION
Color should be `ferrite` not `d2l-asv-font-color` on white background since font-color now changes with theme. White background should have dark text at all times.

![image](https://user-images.githubusercontent.com/64804046/81944078-38f90e00-95ca-11ea-91f7-fe1b6ea71cb4.png)

Issue below only occurs when the [lms PR](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/11643/overview) is merged for sequence viewer. That PR properly sets the `--d2l-asv-text-color` variable so that it matches the chosen theme. Currently the `--d2l-asv-text-color` is always ferrite without this change and is not reflective of the chosen theme.
![image](https://user-images.githubusercontent.com/64804046/81946460-5f6c7880-95cd-11ea-910a-55ea52d12fab.png)

Lots more areas that this affects when `--d2l-asv-text-color` is set properly...
![image](https://user-images.githubusercontent.com/64804046/81948969-4c0edc80-95d0-11ea-8e69-24713379a45e.png)

