### PR TITLE
imcdonald/US116703 Lesson header style changes and performance changes

### DIFF
--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -25,6 +25,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-meter-size: 48px;
+			width: calc(100% - 14px);
+			height: calc(100% - 14px);
 			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
 			margin: 10px var(--d2l-sequence-nav-padding) 10px var(--d2l-sequence-nav-padding);
@@ -32,7 +34,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			display: block;
 			position: relative;
 			z-index: 0;
-			width: 100%;
 		}
 
 		:host(.d2l-asv-current) div.border {
@@ -60,8 +61,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			opacity: 1;
 			background-color: var(--d2l-lesson-header-background-color);
 			z-index: -2;
-			height: 100%;
-			width: 100%;
+			height: calc(100% + 2px);
+			width: calc(100% + 2px);
 		}
 
 		.module-title {
@@ -181,6 +182,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		div.title-container {
 			display: flex;
 			justify-content: space-between;
+			align-items: center;
 		}
 
 		div.title {
@@ -188,6 +190,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		}
 
 		d2l-meter-circle {
+			height: var(--d2l-meter-size);
+			min-height: var(--d2l-meter-size);
 			width: var(--d2l-meter-size);
 			min-width: var(--d2l-meter-size);
 		}

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -22,7 +22,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		return html`
 		<style>
 		:host {
-			--d2l-lesson-header-text-color: var(--d2l-color-ferrite);
+			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-lesson-header-border-color: transparent;
 			--d2l-lesson-header-opacity: 1;
@@ -34,6 +34,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			display: block;
 			position: relative;
 			z-index: 0;
+			width: 100%;
 		}
 
 		:host(.d2l-asv-current) {
@@ -202,7 +203,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 		<siren-entity href="[[_moduleProgressHref]]" token="[[token]]" entity="{{_moduleProgress}}"></siren-entity>
 		<div class="bkgd"></div>
-		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
 			<div class="title-container">
 				<div class="title">
@@ -256,7 +256,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_useModuleIndex: {
 				type: Boolean,
 				value: false,
-				computed: '_checkModuleIndex(entity.properties)'
+				computed: '_checkModuleIndex(_moduleProgress.properties)'
 			},
 			_moduleIndex: {
 				type: Number,
@@ -287,7 +287,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_completionProgress: {
 				type: String,
-				computed: '_getCompletionProgress(entity.properties, _self)'
+				computed: '_getCompletionProgress(entity.properties, _self, _moduleIndex, _siblingModules)'
 			},
 			_moduleProgress: {
 				type: Object

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -30,7 +30,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
 			padding: 9px 10px;
-			display: block;;
+			display: block;
 		}
 
 		a:focus {
@@ -231,15 +231,15 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_useModuleIndex: {
 				type: Boolean,
 				value: false,
-				computed: '_checkModuleIndex(_moduleProgress.properties, entity.properties)'
+				computed: '_checkModuleIndex(_moduleIndex, _siblingModules, _completionProgress)'
 			},
 			_moduleIndex: {
 				type: Number,
-				computed: '_getModuleIndex(_moduleProgress.properties)'
+				computed: '_getModuleIndex(_moduleProgress.properties, entity.properties)'
 			},
 			_siblingModules: {
 				type: Number,
-				computed: '_getSiblingModules(_moduleProgress.properties)'
+				computed: '_getSiblingModules(_moduleProgress.properties, entity.properties)'
 			},
 			_moduleTitle: {
 				type: String,
@@ -315,26 +315,32 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		|| '';
 	}
 
-	_checkModuleIndex(moduleProperties, entityProperties) {
-		if (moduleProperties && moduleProperties.moduleIndex && moduleProperties.numberOfSiblingModules) {
-			return true;
-		} else if (entityProperties && entityProperties.completionProgressLangTerm) {
-			return true;
-		} else {
-			return false;
-		}
+	_checkModuleIndex(moduleIndex, siblingModules, completionProgress) {
+		return moduleIndex && siblingModules && completionProgress !== '';
 	}
 
-	_getModuleIndex(properties) {
-		return properties && properties.moduleIndex;
+	_getModuleIndex(moduleProperties, entityProperties) {
+		if (moduleProperties && moduleProperties.moduleIndex) {
+			return moduleProperties.moduleIndex;
+		} else if (entityProperties && entityProperties.moduleIndex) {
+			return entityProperties.moduleIndex;
+		} else {
+			return null;
+		}
 	}
 
 	_getModuleTitle(properties) {
 		return properties && properties.courseName;
 	}
 
-	_getSiblingModules(properties) {
-		return properties && properties.numberOfSiblingModules;
+	_getSiblingModules(moduleProperties, entityProperties) {
+		if (moduleProperties && moduleProperties.numberOfSiblingModules) {
+			return moduleProperties.numberOfSiblingModules;
+		} else if (entityProperties && entityProperties.numberOfSiblingModules) {
+			return entityProperties.numberOfSiblingModules;
+		} else {
+			return null;
+		}
 	}
 
 	_getUseNewProgressBar(properties) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -231,7 +231,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_useModuleIndex: {
 				type: Boolean,
 				value: false,
-				computed: '_checkModuleIndex(_moduleProgress.properties)'
+				computed: '_checkModuleIndex(_moduleProgress.properties, entity.properties)'
 			},
 			_moduleIndex: {
 				type: Number,
@@ -310,13 +310,19 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 	}
 
 	_getCompletionProgress(properties) {
-		return (properties && properties.completionProgressLangTerm)
-		|| (this._moduleIndex && this._siblingModules && this.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules))
+		return properties && properties.completionProgressLangTerm
+		|| this._moduleIndex && this._siblingModules && this.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules)
 		|| '';
 	}
 
-	_checkModuleIndex(properties) {
-		return properties && properties.moduleIndex && properties.numberOfSiblingModules;
+	_checkModuleIndex(moduleProperties, entityProperties) {
+		if (moduleProperties && moduleProperties.moduleIndex && moduleProperties.numberOfSiblingModules) {
+			return true;
+		} else if (entityProperties && entityProperties.completionProgressLangTerm) {
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	_getModuleIndex(properties) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -25,44 +25,17 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-meter-size: 48px;
-			width: calc(100% - 14px);
-			height: calc(100% - 14px);
+			width: calc(100% - 12px);
+			height: calc(100% - 12px);
 			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
-			margin: 10px var(--d2l-sequence-nav-padding) 10px var(--d2l-sequence-nav-padding);
+			margin-right: 10px;
 			padding: 6px;
-			display: block;
-			position: relative;
-			z-index: 0;
-		}
-
-		:host(.d2l-asv-current) div.border {
-			border-style: solid;
-			border-width: 2px;
-			border-color: var(--d2l-asv-text-color);
-			border-radius: 5px;
-			z-index: -1;
-			height: calc(100% - 2px);
-			width: calc(100% - 2px);
+			display: block;;
 		}
 
 		a:focus {
 			outline: none;
-		}
-
-		div.bkgd, div.border {
-			position: absolute;
-			top: 0;
-			left: 0;
-			border-radius: 8px;
-		}
-
-		div.bkgd {
-			opacity: 1;
-			background-color: var(--d2l-lesson-header-background-color);
-			z-index: -2;
-			height: calc(100% + 2px);
-			width: calc(100% + 2px);
 		}
 
 		.module-title {
@@ -206,8 +179,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		</style>
 
 		<siren-entity href="[[_moduleProgressHref]]" token="[[token]]" entity="{{_moduleProgress}}"></siren-entity>
-		<div class="bkgd"></div>
-		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
 			<div class="title-container">
 				<div class="title">

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -299,7 +299,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 
 		this._lightMeter = opacity >= 1 &&
-			this.currentActivity === this._selfLink &&
 			bkgdColour !== 'transparent' &&
 			!isColorAccessible(bkgdColour, ferrite);
 	}

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -198,8 +198,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		div.unit-info {
 			font-size: 14px;
 		}
-
 		</style>
+
+		<siren-entity href="[[_moduleProgressHref]]" token="[[token]]" entity="{{_moduleProgress}}"></siren-entity>
 		<div class="bkgd"></div>
 		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
@@ -248,6 +249,10 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 				notify: true,
 				observer: '_lightenMeter'
 			},
+			_moduleProgressHref: {
+				type: String,
+				computed: '_getModuleProgressHref(entity)'
+			},
 			_useModuleIndex: {
 				type: Boolean,
 				value: false,
@@ -255,11 +260,11 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_moduleIndex: {
 				type: Number,
-				computed: '_getModuleIndex(entity.properties)'
+				computed: '_getModuleIndex(_moduleProgress.properties)'
 			},
 			_siblingModules: {
 				type: Number,
-				computed: '_getSiblingModules(entity.properties)'
+				computed: '_getSiblingModules(_moduleProgress.properties)'
 			},
 			_moduleTitle: {
 				type: String,
@@ -283,6 +288,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_completionProgress: {
 				type: String,
 				computed: '_getCompletionProgress(entity.properties, _self)'
+			},
+			_moduleProgress: {
+				type: Object
 			},
 			_self: Object
 		};
@@ -360,6 +368,11 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_getUseNewProgressBar(properties) {
 		return properties && properties.useNewProgressBar;
+	}
+
+	_getModuleProgressHref(entity) {
+		const rootLink = entity && entity.getLinkByRel('module-progress-info');
+		return rootLink && rootLink.href || '';
 	}
 }
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -333,8 +333,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 	}
 
 	_getCompletionProgress(properties) {
-		return properties &&  properties.completionProgressLangTerm
-		|| this._self && this._self.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules)
+		return (properties && properties.completionProgressLangTerm)
+		|| (this._self && this._moduleIndex && this._siblingModules && this._self.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules))
 		|| '';
 	}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -25,12 +25,11 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-meter-size: 48px;
-			width: calc(100% - 12px);
-			height: calc(100% - 12px);
+			width: calc(100% - 20px);
+			height: calc(100% - 18px);
 			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
-			margin-right: 10px;
-			padding: 6px;
+			padding: 9px 10px;
 			display: block;;
 		}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -266,8 +266,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_moduleProgress: {
 				type: Object
-			},
-			_self: Object
+			}
 		};
 	}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -24,7 +24,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		:host {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
-			--d2l-lesson-header-opacity: 1;
 			--d2l-meter-size: 48px;
 			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
@@ -36,21 +35,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			width: 100%;
 		}
 
-		/* TODO: figure out styles on hover */
-		/* :host(.d2l-asv-current) {
-			--d2l-lesson-header-background-color: white;
-		} */
-
 		a:focus {
 			outline: none;
 		}
-
-		/* TODO: figure out styles on hover */
-		/* :host(.d2l-asv-focus-within:not(.hide-description)),
-		:host(:hover:not(.hide-description)) {
-			--d2l-lesson-header-text-color: var(--d2l-color-ferrite);
-			--d2l-lesson-header-opacity: 0.26;
-		} */
 
 		div.bkgd, div.border {
 			position: absolute;
@@ -59,8 +46,18 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			border-radius: 8px;
 		}
 
+		:host(.d2l-asv-current) div.border {
+			border-style: solid;
+			border-width: 1px;
+			border-color: var(--d2l-asv-text-color);
+			border-radius: 5px;
+			z-index: -1;
+			height: calc(100% - 2px);
+			width: calc(100% - 2px);
+		}
+
 		div.bkgd {
-			opacity: var(--d2l-lesson-header-opacity);
+			opacity: 1;
 			background-color: var(--d2l-lesson-header-background-color);
 			z-index: -2;
 			height: 100%;
@@ -101,22 +98,26 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			background-color: var(--d2l-color-gypsum);
 			height:12px;
 		}
+
 		/* this is necessary to avoid white bleed over rounded corners in chrome and safari */
 		progress.d2l-progress::-webkit-progress-bar {
 			@apply --d2l-progress-webkit-progress-bar;
 		}
+
 		/* strangely, comma separating the selectors for these pseudo-elements causes them to break */
 		progress.d2l-progress::-webkit-progress-value {
 			@apply --d2l-progress-webkit-progress-value;
 			background-color: var(--d2l-color-celestine);
 			border:none;
 		}
+
 		/* note: unable to get firefox to animate the width... seems animation is not implemented for progress in FF */
 		progress.d2l-progress::-moz-progress-bar {
 			@apply --d2l-progress-moz-progress-bar;
 			background-color: var(--d2l-color-celestine);
 			border:none;
 		}
+
 		progress.d2l-progress::-ms-fill {
 			@apply --d2l-progress-ms-fill;
 			border: 1px solid transparent;
@@ -125,24 +126,30 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12837456/*/
 			background-color: var(--d2l-color-celestine, #006fbf);
 		}
+
 		:host(.hide-description) .d2l-header-lesson-link,
 		:host(.hide-description) .d2l-header-lesson-link:hover {
 			cursor:default;
 		}
+
 		:host(.d2l-asv-current) progress.d2l-progress {
 			background-color: transparent;
 			border: 1px solid var(--d2l-asv-selected-text-color);
 			box-shadow: none;
 		}
+
 		:host(.d2l-asv-current) progress.d2l-progress::-webkit-progress-value {
 			background-color: var(--d2l-asv-selected-text-color);
 		}
+
 		:host(.d2l-asv-current) progress.d2l-progress::-moz-progress-bar {
 			background-color: var(--d2l-asv-selected-text-color);
 		}
+
 		:host(.d2l-asv-current) progress.d2l-progress::-ms-fill {
 			background-color: var(--d2l-asv-selected-text-color, #fff);
 		}
+
 		/* Added light-theme id as a workaround for Edge issue with variables in -ms-fill
 		https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12837456/ */
 		:host(.d2l-asv-current) progress.d2l-progress#light-theme::-ms-fill {
@@ -155,14 +162,17 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			border: 1px solid var(--d2l-color-ferrite);
 			box-shadow: none;
 		}
+
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-webkit-progress-value,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-webkit-progress-value {
 			background-color: var(--d2l-color-ferrite);
 		}
+
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-moz-progress-bar,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-moz-progress-bar {
 			background-color: var(--d2l-color-ferrite);
 		}
+
 		:host(.d2l-asv-focus-within:not(.hide-description)) progress.d2l-progress::-ms-fill,
 		:host(:hover:not(.hide-description)) progress.d2l-progress::-ms-fill {
 			background-color: var(--d2l-color-ferrite, #565a5c);
@@ -172,9 +182,11 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			display: flex;
 			justify-content: space-between;
 		}
+
 		div.title {
 			width: calc(100% - var(--d2l-meter-size));
 		}
+
 		d2l-meter-circle {
 			width: var(--d2l-meter-size);
 			min-width: var(--d2l-meter-size);
@@ -191,6 +203,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 		<siren-entity href="[[_moduleProgressHref]]" token="[[token]]" entity="{{_moduleProgress}}"></siren-entity>
 		<div class="bkgd"></div>
+		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
 			<div class="title-container">
 				<div class="title">
@@ -295,11 +308,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 	_lightenMeter() {
 		const style = getComputedStyle(this);
 		const bkgdColour = style.getPropertyValue('--d2l-asv-primary-color').trim();
-		const opacity = style.getPropertyValue('--d2l-lesson-header-opacity');
 		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 
-		this._lightMeter = opacity >= 1 &&
-			bkgdColour !== 'transparent' &&
+		this._lightMeter = bkgdColour !== 'transparent' &&
 			!isColorAccessible(bkgdColour, ferrite);
 	}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -35,6 +35,16 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			width: 100%;
 		}
 
+		:host(.d2l-asv-current) div.border {
+			border-style: solid;
+			border-width: 2px;
+			border-color: var(--d2l-asv-text-color);
+			border-radius: 5px;
+			z-index: -1;
+			height: calc(100% - 2px);
+			width: calc(100% - 2px);
+		}
+
 		a:focus {
 			outline: none;
 		}
@@ -44,16 +54,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			top: 0;
 			left: 0;
 			border-radius: 8px;
-		}
-
-		:host(.d2l-asv-current) div.border {
-			border-style: solid;
-			border-width: 1px;
-			border-color: var(--d2l-asv-text-color);
-			border-radius: 5px;
-			z-index: -1;
-			height: calc(100% - 2px);
-			width: calc(100% - 2px);
 		}
 
 		div.bkgd {
@@ -295,14 +295,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_self: Object
 		};
-	}
-
-	ready() {
-		super.ready();
-		// TODO: figure out if this is necessary
-		// this.addEventListener('mouseover', this._lightenMeter);
-		// this.addEventListener('mouseout', this._lightenMeter);
-		// this.addEventListener('blur', this._lightenMeter);
 	}
 
 	_lightenMeter() {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -24,10 +24,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		:host {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
-			--d2l-lesson-header-border-color: transparent;
 			--d2l-lesson-header-opacity: 1;
 			--d2l-meter-size: 48px;
-			background-color: transparent;
+			background-color: var(--d2l-lesson-header-background-color);
 			color: var(--d2l-lesson-header-text-color);
 			margin: 10px var(--d2l-sequence-nav-padding) 10px var(--d2l-sequence-nav-padding);
 			padding: 6px;
@@ -37,23 +36,21 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			width: 100%;
 		}
 
-		:host(.d2l-asv-current) {
-			--d2l-lesson-header-background-color: var(--d2l-asv-primary-color);
-			--d2l-lesson-header-text-color: var(--d2l-asv-selected-text-color);
-			--d2l-lesson-header-border-color: rgba(0, 0, 0, 0.6);
-		}
+		/* TODO: figure out styles on hover */
+		/* :host(.d2l-asv-current) {
+			--d2l-lesson-header-background-color: white;
+		} */
 
 		a:focus {
 			outline: none;
 		}
 
-		:host(.d2l-asv-focus-within:not(.hide-description)),
+		/* TODO: figure out styles on hover */
+		/* :host(.d2l-asv-focus-within:not(.hide-description)),
 		:host(:hover:not(.hide-description)) {
-			--d2l-lesson-header-background-color: var(--d2l-asv-primary-color);
-			--d2l-lesson-header-border-color: rgba(0, 0, 0, 0.42);
 			--d2l-lesson-header-text-color: var(--d2l-color-ferrite);
 			--d2l-lesson-header-opacity: 0.26;
-		}
+		} */
 
 		div.bkgd, div.border {
 			position: absolute;
@@ -68,15 +65,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			z-index: -2;
 			height: 100%;
 			width: 100%;
-		}
-
-		div.border {
-			border-style: solid;
-			border-width: 1px;
-			border-color: var(--d2l-lesson-header-border-color);
-			z-index: -1;
-			height: calc(100% - 2px);
-			width: calc(100% - 2px);
 		}
 
 		.module-title {
@@ -306,7 +294,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_lightenMeter() {
 		const style = getComputedStyle(this);
-		const bkgdColour = style.getPropertyValue('--d2l-lesson-header-background-color').trim();
+		const bkgdColour = style.getPropertyValue('--d2l-asv-primary-color').trim();
 		const opacity = style.getPropertyValue('--d2l-lesson-header-opacity');
 		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -276,6 +276,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 
 		this._lightMeter = bkgdColour !== 'transparent' &&
+			bkgdColour !== '' &&
 			!isColorAccessible(bkgdColour, ferrite);
 	}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -231,7 +231,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_useModuleIndex: {
 				type: Boolean,
 				value: false,
-				computed: '_checkModuleIndex(_moduleIndex, _siblingModules, _completionProgress)'
+				computed: '_checkCompletionProgress(_completionProgress)'
 			},
 			_moduleIndex: {
 				type: Number,
@@ -315,8 +315,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		|| '';
 	}
 
-	_checkModuleIndex(moduleIndex, siblingModules, completionProgress) {
-		return moduleIndex && siblingModules && completionProgress !== '';
+	_checkCompletionProgress(completionProgress) {
+		return completionProgress && completionProgress !== '';
 	}
 
 	_getModuleIndex(moduleProperties, entityProperties) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -275,7 +275,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_completionProgress: {
 				type: String,
-				computed: '_getCompletionProgress(entity.properties, _self, _moduleIndex, _siblingModules)'
+				computed: '_getCompletionProgress(entity.properties, _moduleIndex, _siblingModules)'
 			},
 			_moduleProgress: {
 				type: Object
@@ -286,10 +286,10 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	ready() {
 		super.ready();
-		this.addEventListener('mouseover', this._lightenMeter);
-		this.addEventListener('mouseout', this._lightenMeter);
-		this.addEventListener('blur', this._lightenMeter);
-		this._self = this;
+		// TODO: figure out if this is necessary
+		// this.addEventListener('mouseover', this._lightenMeter);
+		// this.addEventListener('mouseout', this._lightenMeter);
+		// this.addEventListener('blur', this._lightenMeter);
 	}
 
 	_lightenMeter() {
@@ -323,6 +323,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		}
 		this.currentActivity = this._selfLink;
 	}
+
 	isLightTheme() {
 		var styles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));
 		if (styles && styles['--d2l-asv-selected-text-color'] === 'var(--d2l-color-ferrite)') {
@@ -333,7 +334,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_getCompletionProgress(properties) {
 		return (properties && properties.completionProgressLangTerm)
-		|| (this._self && this._moduleIndex && this._siblingModules && this._self.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules))
+		|| (this._moduleIndex && this._siblingModules && this.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules))
 		|| '';
 	}
 

--- a/test/d2l-sequence-navigator/d2l-lesson-header.html
+++ b/test/d2l-sequence-navigator/d2l-lesson-header.html
@@ -81,11 +81,8 @@ describe('d2l-lesson-header', () => {
 				.text('Lesson 1');
 		});
 
-		it('should display module index given index and total', () => {
-			const useModuleIndex = !!element._checkModuleIndex({
-				moduleIndex: 2,
-				numberOfSiblingModules: 4
-			});
+		it('should display module index information given completion progress', () => {
+			const useModuleIndex = !!element._checkCompletionProgress('module 2 of 4');
 			expect(useModuleIndex)
 				.to
 				.equal(true);

--- a/test/d2l-sequence-navigator/d2l-lesson-header.html
+++ b/test/d2l-sequence-navigator/d2l-lesson-header.html
@@ -193,20 +193,6 @@ describe('d2l-lesson-header', () => {
 
 	});
 
-	describe('without unit completionProgressLangTerm', () => {
-		let element;
-		beforeEach(async()=> {
-			element = await SirenFixture('data/lesson-enhanced.json', fixture('LightBackgroundFixture'));
-		});
-		it('should use the referenced lang term', async() => {
-			const unitInfo = element.shadowRoot.querySelector('.unit-info :last-child');
-			expect(unitInfo.innerText)
-				.to
-				.equal('Unit 2 of 4');
-		});
-
-	});
-
 	describe('with the hide-description class', () => {
 		let element;
 		beforeEach(async() => {

--- a/test/d2l-sequence-navigator/data/lesson-enhanced.json
+++ b/test/d2l-sequence-navigator/data/lesson-enhanced.json
@@ -1,8 +1,6 @@
 {
 	"properties": {
 		"title": "Lesson 1",
-		"moduleIndex": 2,
-		"numberOfSiblingModules": 4,
 		"courseName": "My best course",
 		"useNewProgressBar": true
 	},
@@ -45,6 +43,9 @@
 	}, {
 		"rel": ["up"],
 		"href": "data/unit1.json"
+	}, {
+		"rel": ["module-progress-info"],
+		"href": "data/module-progress-info.json"
 	}],
 	"class": ["sequence", "sequence-description"]
 }

--- a/test/d2l-sequence-navigator/data/module-progress-info.json
+++ b/test/d2l-sequence-navigator/data/module-progress-info.json
@@ -1,0 +1,11 @@
+{
+	"class": ["module-progress-info"],
+	"properties": {
+		"moduleIndex": 2,
+		"numberOfSiblingModules": 4
+	},
+	"links": [{
+		"rel": ["self"],
+		"href": "data/module-progress-info.json"
+	}]
+}


### PR DESCRIPTION
Styling `d2l-lesson-header` so it reflects updates in sequence navigator designs outlined [here](https://xd.adobe.com/view/e16d4c3f-77f8-4632-6a01-a98beb7c5072-975c/screen/2fc07bba-3928-4455-a3c2-589589994d8d/Specs-Navigation-Button-States/).

Also adjusting `moduleIndex` and `siblingModules` so they fetch information from the new location with Al's performance changes.