### PR TITLE
Align sidenav components to design spec

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -217,11 +217,21 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				display: block;
 			}
 
+			:host([header-focused][accordion-state="closed"]) #header-container {
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
+			}
+
+			:host([header-focused][accordion-state="open"]) #header-container {
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 4px #ffffff inset, 0 0 0 6px var(--d2l-color-celestine) inset;
+				border-radius: 12px;
+			}
 		</style>
 
 		<siren-entity href="[[lastViewedContentObject]]" token="[[token]]" entity="{{_lastViewedContentObjectEntity}}"></siren-entity>
 		<siren-entity href="[[currentActivity]]" token="[[token]]" entity="{{_currentActivityEntity}}"></siren-entity>
-		<d2l-labs-accordion-collapse no-icons="" flex="" has-focus-style>
+		<d2l-labs-accordion-collapse no-icons="" flex="" disable-default-trigger-focus>
 			<div slot="header" id="header-container" class$="[[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription)]]">
 				<div id="header-skeleton-container">
 					<div id="header-skeleton" class="skeleton"></div>
@@ -397,7 +407,12 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				type: String,
 				reflectToAttribute: true,
 				value: 'closed'
-			}
+			},
+			headerFocused: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
 		};
 	}
 
@@ -413,12 +428,16 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		super.connectedCallback();
 		this.addEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
+		this.addEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
+		this.addEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
+		this.removeEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
+		this.removeEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
 	}
 
 	_isAccordionOpen() {
@@ -661,6 +680,14 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 
 	_showChildSkeletons(showLoadingSkeleton, _childrenLoading) {
 		return showLoadingSkeleton || _childrenLoading;
+	}
+
+	_onHeaderFocus() {
+		this.headerFocused = true;
+	}
+
+	_onHeaderBlur() {
+		this.headerFocused = false;
 	}
 }
 customElements.define(D2LSequenceLauncherModule.is, D2LSequenceLauncherModule);

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -554,8 +554,10 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 	}
 
 	_onLaunchModuleButtonClick() {
-		this.currentActivity = this.entity.getLinkByRel('self').href;
-		this._contentObjectClick();
+		if (!this._hideModuleDescription) {
+			this.currentActivity = this.entity.getLinkByRel('self').href;
+			this._contentObjectClick();
+		}
 	}
 
 	_getShowModuleChildren(_moduleStartOpen, _moduleWasExpanded) {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -46,10 +46,10 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				background-color: var(--d2l-color-gypsum);
 			}
 
-			:host([accordion-state="open"]) #header-container:hover {
+			:host([accordion-state="open"]) #header-container:hover .module-header {
 				background-color: var(--d2l-color-gypsum);
-				box-shadow: 0 0 0 6px #ffffff inset;
-				border-radius: 12px;
+				box-shadow: 0 0 0 8px var(--d2l-color-gypsum), 0 0 0 10px #ffffff;
+				border-radius: 2px;
 			}
 
 			#header-container:hover * {
@@ -217,10 +217,14 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 			}
 
-			:host([header-focused][accordion-state="open"]) #header-container {
+			:host([header-focused][accordion-state="open"]) .module-header {
 				background-color: var(--d2l-color-gypsum);
-				box-shadow: 0 0 0 4px #ffffff inset, 0 0 0 6px var(--d2l-color-celestine) inset;
-				border-radius: 12px;
+				border-radius: 2px;
+    			box-shadow: 0 0 0 8px var(--d2l-color-gypsum), 0 0 0 10px #ffffff, 0 0 0 12px var(--d2l-color-celestine);
+			}
+
+			:host([header-focused]) .module-title {
+				color: var(--d2l-color-celestine-minus-1);
 			}
 		</style>
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -24,11 +24,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				--d2l-outer-module-text-color: var(--d2l-color-ferrite);
 			}
 
-			d2l-labs-accordion-collapse:focus {
-				outline: none;
-				border: 2px solid var(--d2l-color-celestine);
-			}
-
 			d2l-labs-accordion-collapse {
 				border: 1px solid var(--d2l-color-mica);
 				border-radius: 6px;

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -39,11 +39,26 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				padding: 15px 18px;
 				color: var(--d2l-outer-module-text-color);
 				cursor: pointer;
+				border-radius: 6px;
 			}
 
 			#header-container.hide-description,
 			:host([show-loading-skeleton]) #header-container {
 				cursor: default;
+			}
+
+			:host([accordion-state="closed"]) #header-container:hover {
+				background-color: var(--d2l-color-gypsum);
+			}
+
+			:host([accordion-state="open"]) #header-container:hover {
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 6px #ffffff inset;
+				border-radius: 12px;
+			}
+
+			#header-container:hover * {
+				color: var(--d2l-color-celestine-minus-1);
 			}
 
 			.start-date-text {
@@ -377,6 +392,11 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 			isSidebar: {
 				type: Boolean,
 				reflectToAttribute: true
+			},
+			accordionState: {
+				type: String,
+				reflectToAttribute: true,
+				value: 'closed'
 			}
 		};
 	}
@@ -392,13 +412,13 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 	connectedCallback() {
 		super.connectedCallback();
 		this.addEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
-		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseIconName);
+		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
-		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseIconName);
+		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
 	}
 
 	_isAccordionOpen() {
@@ -479,7 +499,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 			return false;
 		}
 		// Set the starting icon depending on the collapse state
-		this._updateCollapseIconName();
+		this._updateCollapseStateAndIconName();
 
 		// FixMe: This is kind of gross. ideally we decouple all the isSidebar stuff into separate components
 		// If this is a sidebar, we use the currentActivity to detect if this should be open.
@@ -578,11 +598,13 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		return hasActiveTopic || hasActiveModule;
 	}
 
-	_updateCollapseIconName() {
+	_updateCollapseStateAndIconName() {
 		if (this._isAccordionOpen()) {
 			this._iconName = 'tier1:arrow-collapse-small';
+			this.accordionState = 'open';
 		} else {
 			this._iconName = 'tier1:arrow-expand-small';
+			this.accordionState = 'closed';
 		}
 	}
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -275,7 +275,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 							aria-label$="[[localize('sequenceNavigator.launchModule')]]"
 							text="[[localize('sequenceNavigator.launchModule')]]"
 							icon="tier1:move-to"
-							on-click="_onLaunchModuleButtonClick"
 						></d2l-button-subtle>
 					</template>
 				</div>
@@ -429,6 +428,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
 		this.addEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
 		this.addEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
+		this.addEventListener('d2l-labs-accordion-collapse-state-opened', this._onLaunchModuleButtonClick);
 	}
 
 	disconnectedCallback() {
@@ -437,6 +437,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
 		this.removeEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
 		this.removeEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
+		this.removeEventListener('d2l-labs-accordion-collapse-state-opened', this._onLaunchModuleButtonClick);
 	}
 
 	_isAccordionOpen() {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -426,8 +426,8 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		super.connectedCallback();
 		this.addEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
-		this.addEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
-		this.addEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
+		this.addEventListener('d2l-labs-accordion-collapse-toggle-focus', this._onHeaderFocus);
+		this.addEventListener('d2l-labs-accordion-collapse-toggle-blur', this._onHeaderBlur);
 		this.addEventListener('d2l-labs-accordion-collapse-state-opened', this._onLaunchModuleButtonClick);
 	}
 
@@ -435,8 +435,8 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		super.disconnectedCallback();
 		this.removeEventListener('d2l-labs-accordion-collapse-clicked', this._onHeaderClicked);
 		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._updateCollapseStateAndIconName);
-		this.removeEventListener('d2l-labs-accordion-toggle-focus', this._onHeaderFocus);
-		this.removeEventListener('d2l-labs-accordion-toggle-blur', this._onHeaderBlur);
+		this.removeEventListener('d2l-labs-accordion-collapse-toggle-focus', this._onHeaderFocus);
+		this.removeEventListener('d2l-labs-accordion-collapse-toggle-blur', this._onHeaderBlur);
 		this.removeEventListener('d2l-labs-accordion-collapse-state-opened', this._onLaunchModuleButtonClick);
 	}
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -42,20 +42,6 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				cursor: default;
 			}
 
-			:host([accordion-state="closed"]) #header-container:hover {
-				background-color: var(--d2l-color-gypsum);
-			}
-
-			:host([accordion-state="open"]) #header-container:hover .module-header {
-				background-color: var(--d2l-color-gypsum);
-				box-shadow: 0 0 0 8px var(--d2l-color-gypsum), 0 0 0 10px #ffffff;
-				border-radius: 2px;
-			}
-
-			#header-container:hover * {
-				color: var(--d2l-color-celestine-minus-1);
-			}
-
 			.start-date-text {
 				margin: 0;
 				text-align: right;
@@ -210,6 +196,20 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 				height: 24px;
 				width: 20%;
 				display: block;
+			}
+
+			:host([accordion-state="closed"]) #header-container:hover {
+				background-color: var(--d2l-color-gypsum);
+			}
+
+			:host([accordion-state="open"]) #header-container:hover .module-header {
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 8px var(--d2l-color-gypsum), 0 0 0 10px #ffffff;
+				border-radius: 2px;
+			}
+
+			#header-container:hover * {
+				color: var(--d2l-color-celestine-minus-1);
 			}
 
 			:host([header-focused][accordion-state="closed"]) #header-container {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -221,7 +221,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 
 		<siren-entity href="[[lastViewedContentObject]]" token="[[token]]" entity="{{_lastViewedContentObjectEntity}}"></siren-entity>
 		<siren-entity href="[[currentActivity]]" token="[[token]]" entity="{{_currentActivityEntity}}"></siren-entity>
-		<d2l-labs-accordion-collapse no-icons="" flex="">
+		<d2l-labs-accordion-collapse no-icons="" flex="" has-focus-style>
 			<div slot="header" id="header-container" class$="[[isEmpty(subEntities)]] [[_getHideDescriptionClass(_hideModuleDescription)]]">
 				<div id="header-skeleton-container">
 					<div id="header-skeleton" class="skeleton"></div>

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -25,7 +25,7 @@ PolymerElement
 			:host {
 				display: block;
 				height: 100%;
-				border: 1px solid var(--d2l-color-mica);
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 1px var(--d2l-color-mica);
 				border-bottom-left-radius: 6px;
 				border-bottom-right-radius: 6px;
 			}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -25,7 +25,6 @@ PolymerElement
 			:host {
 				display: block;
 				height: 100%;
-				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 				border-bottom-left-radius: 6px;
 				border-bottom-right-radius: 6px;
 			}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -25,7 +25,7 @@ PolymerElement
 			:host {
 				display: block;
 				height: 100%;
-				box-shadow: 0 0 0 2px #ffffff, 0 0 0 1px var(--d2l-color-mica);
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 				border-bottom-left-radius: 6px;
 				border-bottom-right-radius: 6px;
 			}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -34,7 +34,7 @@ PolymerElement
 
 			.module-item-list {
 				list-style-type: none;
-				padding: 0 18px;
+				padding: 0 30px;
 				margin: 0;
 			}
 
@@ -54,6 +54,18 @@ PolymerElement
 
 			li {
 				padding-top: 6px;
+			}
+
+			@media(max-width: 929px) {
+				.module-item-list {
+					padding: 0 24px;
+				}
+			}
+
+			@media(max-width: 767px) {
+				.module-item-list {
+					padding: 0 18px;
+				}
 			}
 		</style>
 		<siren-entity href="[[rootHref]]" token="[[token]]" entity="{{_lessonEntity}}"></siren-entity>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -24,7 +24,18 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#content-container:focus,
 			#content-container:focus-within {
 				outline: none;
-				border: 2px solid var(--d2l-color-celestine);
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
+				background-color: var(--d2l-color-gypsum);
+			}
+
+			#content-container:focus,
+			#content-container:focus-within a {
+				color: var(--d2l-color-celestine-minus-1);
+			}
+
+			#content-container:focus,
+			#content-container:focus-within d2l-icon {
+				color: var(--d2l-color-celestine-minus-1);
 			}
 
 			:host > div {
@@ -40,6 +51,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			:host([show-underline]) > #outer-container {
 				border-bottom: 1px solid var(--d2l-color-mica);
 			}
+
 			#outer-container {
 				border-bottom: 1px solid transparent;
 				display: flex;

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -24,7 +24,18 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#module-header:focus,
 			#module-header:focus-within {
 				outline: none;
-				border: 2px solid var(--d2l-color-celestine);
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
+			}
+
+			#module-header:focus,
+			#module-header:focus-within d2l-icon {
+				color: var(--d2l-color-celestine-minus-1);
+			}
+
+			#module-header:focus,
+			#module-header:focus-within a {
+				color: var(--d2l-color-celestine-minus-1);
 			}
 
 			#title-container {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "main": "d2l-sequences.js",
   "dependencies": {
     "@brightspace-ui/core": "^1",
-    "@brightspace-ui-labs/accordion": "^2.0.2",
+    "@brightspace-ui-labs/accordion": "^2.3.0",
     "@d2l/audio": "Brightspace/d2l-audio#semver:^3",
     "@d2l/video": "Brightspace/d2l-video#semver:^1",
     "@polymer/iron-collapse": "^3.0.0-pre.18",


### PR DESCRIPTION
Align left navigation to design spec. This PR tweaks the styles of various components to align with styles outlined on the link below. Main changes are the hover and focus states of component. Accordion changes were made so a version bump was required in `package.json`.

Links:
- [Rally Ticket](https://rally1.rallydev.com/#/289692574792d/detail/userstory/393476310436?fdp=true)
- [Design Spec](https://xd.adobe.com/view/e16d4c3f-77f8-4632-6a01-a98beb7c5072-975c/screen/2fc07bba-3928-4455-a3c2-589589994d8d/Specs-Navigation-Button-States?x_product=cc-slack%2F1.5.0)