### PR TITLE
Add end of unit to side-nav

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -28,6 +28,7 @@ PolymerElement
 				border-bottom-left-radius: 6px;
 				border-bottom-right-radius: 6px;
 			}
+
 			:host([is-sidebar]) {
 				border: none;
 			}
@@ -43,6 +44,7 @@ PolymerElement
 				overflow-y: auto;
 				overflow-x: hidden;
 			}
+
 			li:first-of-type d2l-activity-link,
 			li:first-of-type {
 				margin-top: 10px;

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -5,6 +5,7 @@ import '@brightspace-ui-labs/accordion/accordion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import 'siren-entity/siren-entity.js';
 import '../localize-behavior.js';
+import '../d2l-sequence-navigator/d2l-sequence-end.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -34,7 +35,7 @@ PolymerElement
 
 			.module-item-list {
 				list-style-type: none;
-				padding: 0 30px;
+				padding: 0;
 				margin: 0;
 			}
 
@@ -56,14 +57,18 @@ PolymerElement
 				padding-top: 6px;
 			}
 
+			.module-content {
+				padding: 0 30px;
+			}
+
 			@media(max-width: 929px) {
-				.module-item-list {
+				.module-content {
 					padding: 0 24px;
 				}
 			}
 
 			@media(max-width: 767px) {
-				.module-item-list {
+				.module-content {
 					padding: 0 18px;
 				}
 			}
@@ -103,6 +108,12 @@ PolymerElement
 					</template>
 				</template>
 			</ol>
+			<d2l-sequence-end
+				href="[[_sequenceEndHref]]"
+				token="[[token]]"
+				current-activity="{{href}}"
+				text="[[localize('endOfSequence')]]"
+			></d2l-sequence-end>
 		</d2l-labs-accordion>
 		`;
 	}
@@ -146,6 +157,10 @@ PolymerElement
 			_childrenLoadingTracker: {
 				type: Object,
 				computed: '_setUpChildrenLoadingTracker(subEntities)'
+			},
+			_sequenceEndHref: {
+				type: String,
+				computed: '_getSequenceEndHref(entity)'
 			},
 			isSidebar: {
 				type: Boolean,
@@ -248,6 +263,11 @@ PolymerElement
 
 	_showChildSkeletons(showLoadingSkeleton, _childrenLoading) {
 		return showLoadingSkeleton || _childrenLoading;
+	}
+
+	_getSequenceEndHref(entity) {
+		const endOfSequenceLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/end-of-sequence');
+		return endOfSequenceLink && endOfSequenceLink.href || '';
 	}
 }
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -5,7 +5,6 @@ import '@brightspace-ui-labs/accordion/accordion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import 'siren-entity/siren-entity.js';
 import '../localize-behavior.js';
-import '../d2l-sequence-navigator/d2l-sequence-end.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -107,13 +106,7 @@ PolymerElement
 						</li>
 					</template>
 				</template>
-			</ol>
-			<d2l-sequence-end
-				href="[[_sequenceEndHref]]"
-				token="[[token]]"
-				current-activity="{{href}}"
-				text="[[localize('endOfSequence')]]"
-			></d2l-sequence-end>
+			<slot name="end-of-lesson"></slot>
 		</d2l-labs-accordion>
 		`;
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -109,7 +109,7 @@ PolymerElement
 					</template>
 				</template>
 			</ol>
-			<slot name="end-of-lesson"></slot>
+			<slot name="end-of-unit"></slot>
 		</d2l-labs-accordion>
 		`;
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -106,6 +106,7 @@ PolymerElement
 						</li>
 					</template>
 				</template>
+			</ol>
 			<slot name="end-of-lesson"></slot>
 		</d2l-labs-accordion>
 		`;

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -151,10 +151,6 @@ PolymerElement
 				type: Object,
 				computed: '_setUpChildrenLoadingTracker(subEntities)'
 			},
-			_sequenceEndHref: {
-				type: String,
-				computed: '_getSequenceEndHref(entity)'
-			},
 			isSidebar: {
 				type: Boolean,
 				reflectToAttribute: true,
@@ -256,11 +252,6 @@ PolymerElement
 
 	_showChildSkeletons(showLoadingSkeleton, _childrenLoading) {
 		return showLoadingSkeleton || _childrenLoading;
-	}
-
-	_getSequenceEndHref(entity) {
-		const endOfSequenceLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/end-of-sequence');
-		return endOfSequenceLink && endOfSequenceLink.href || '';
 	}
 }
 

--- a/d2l-sequence-navigator/d2l-sequence-end.js
+++ b/d2l-sequence-navigator/d2l-sequence-end.js
@@ -12,74 +12,39 @@ class D2LSequenceEnd extends ASVFocusWithinMixin(
 		return html`
 			<style>
 				#d2l-sequence-end-container {
-					--d2l-sequence-end-text-color: var(--d2l-color-ferrite);
-					--d2l-sequence-end-background-color: transparent;
-					--d2l-sequence-end-border-color: var(--d2l-sequence-end-background-color);
-					--d2l-sequence-end-opacity: 1;
-					background-color: transparent;
-					color: var(--d2l-sequence-end-text-color);
-					border-style: solid;
-					border-width: 1px;
-					border-color: transparent;
-					border-radius: 8px 0px 0px 8px;
+					color: var(--d2l-color-ferrite);
+					border-radius: 6px;
 					padding: 20px 40px 20px 20px;
 					position: relative;
-					z-index: 0;
-					margin-top: 6px;
-					margin-right: var(--d2l-sequence-nav-padding);
-					margin-left: var(--d2l-sequence-nav-padding);
+					margin: 6px 0;
 				}
 
 				#d2l-sequence-end-container.d2l-asv-current {
-					--d2l-sequence-end-background-color: var(--d2l-asv-primary-color);
-					--d2l-sequence-end-text-color: var(--d2l-asv-selected-text-color);
-					--d2l-sequence-end-border-color: rgba(0, 0, 0, 0.6);
+					background-color: var(--d2l-color-gypsum);
+					color: var(--d2l-color-celestine-minus-1);
 				}
 
 				#d2l-sequence-end-container.d2l-asv-focus-within,
-				#d2l-sequence-end-container:focus:not(.d2l-asv-current),
+				#d2l-sequence-end-container:focus:not(.d2l-asv-current) {
+					box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
+					background-color: var(--d2l-color-gypsum);
+					color: var(--d2l-color-celestine-minus-1);
+				}
+
 				#d2l-sequence-end-container:hover {
-					--d2l-sequence-end-background-color: var(--d2l-asv-primary-color);
-					--d2l-sequence-end-border-color: rgba(0, 0, 0, 0.42);
-					--d2l-sequence-end-text-color: var(--d2l-color-ferrite);
-					--d2l-sequence-end-opacity: 0.26;
+					background-color: var(--d2l-color-gypsum);
+					color: var(--d2l-color-celestine-minus-1);
 					cursor: pointer;
 				}
 
-				div.bkgd, div.border {
-					position: absolute;
-					top: 0px;
-					left: 0px;
-					border-radius: 8px;
-				}
-
-				div.bkgd {
-					opacity: var(--d2l-sequence-end-opacity);
-					background-color: var(--d2l-sequence-end-background-color);
-					z-index: -2;
-					height: 100%;
-					width: 100%;
-				}
-
-				div.border {
-					border-style: solid;
-					border-width: 1px;
-					border-color:  var(--d2l-sequence-end-border-color);
-					z-index: -1;
-					height: calc(100% - 2px);
-					width: calc(100% - 2px);
-				}
-
 				.d2l-sequence-end-link {
-						@apply --d2l-heading-3;
-						color: var(--d2l-sequence-end-text-color);
-						text-decoration: none;
-						outline: none;
+					@apply --d2l-heading-3;
+					color: var(--d2l-sequence-end-text-color);
+					text-decoration: none;
+					outline: none;
 				}
 			</style>
 			<div id="d2l-sequence-end-container" class$="[[_containerClass]]" on-click="showEndOfLesson">
-				<div class="bkgd"></div>
-				<div class="border"></div>
 				<a on-click="showEndOfLesson"
 					class="d2l-sequence-end-link"
 					href="javascript:void(0)">


### PR DESCRIPTION
Adding end of unit link back into side-nav.

There will be another [PR in sequence-viewer](https://github.com/Brightspace/d2l-sequence-viewer/pull/286) adding the component into `d2l-sequence-launcher-unit`

See [rally ticket.](https://rally1.rallydev.com/#/289692574792d/detail/userstory/395635592416?fdp=true)

![end of unit 2](https://user-images.githubusercontent.com/64804046/83882322-f087c880-a70f-11ea-881c-e9ab5a497d4a.gif)
