### PR TITLE
Adjust LX header so it says "lesson" instead of "unit" when useLessonAsRoot configured

### DIFF
--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -262,7 +262,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			},
 			_completionProgress: {
 				type: String,
-				computed: '_getCompletionProgress(entity.properties, _moduleIndex, _siblingModules)'
+				computed: '_getCompletionProgress(entity.properties, _moduleProgress.properties, _moduleIndex, _siblingModules)'
 			},
 			_moduleProgress: {
 				type: Object
@@ -309,10 +309,16 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		return;
 	}
 
-	_getCompletionProgress(properties) {
-		return properties && properties.completionProgressLangTerm
-		|| this._moduleIndex && this._siblingModules && this.localize('sequenceNavigator.currentModule', 'current', this._moduleIndex, 'total', this._siblingModules)
-		|| '';
+	_getCompletionProgress(entityProperties, moduleProperties, _moduleIndex, _siblingModules) {
+		if (entityProperties && entityProperties.completionProgressLangTerm) {
+			return entityProperties.completionProgressLangTerm;
+		} else if (moduleProperties && moduleProperties.completionProgressLangTerm) {
+			return moduleProperties.completionProgressLangTerm;
+		} else if (_moduleIndex && _siblingModules) {
+			return this.localize('sequenceNavigator.currentModule', 'current', _moduleIndex, 'total', _siblingModules);
+		} else {
+			return '';
+		}
 	}
 
 	_checkCompletionProgress(completionProgress) {


### PR DESCRIPTION
Adjust `_completionProgress` conditionals so that the text is properly set. The "lesson" lang term is passed in `moduleProperties.completionProgressLangTerm` on the back-end only when `useLessonAsRoot` is configured. 