### PR TITLE
Fix import on error page

### DIFF
--- a/components/d2l-sequences-content-error.js
+++ b/components/d2l-sequences-content-error.js
@@ -2,7 +2,7 @@ import '../localize-behavior.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-class D2LSequencesContentError extends mixinBehaviors([
+export class D2LSequencesContentError extends mixinBehaviors([
 	D2L.PolymerBehaviors.Sequences.LocalizeBehavior
 ], PolymerElement) {
 	static get template() {

--- a/mixins/d2l-sequences-router-mixin.js
+++ b/mixins/d2l-sequences-router-mixin.js
@@ -1,4 +1,5 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { D2LSequencesContentError } from '../components/d2l-sequences-content-error';
 import '../components/d2l-sequences-content-error.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { TemplateStamp } from '@polymer/polymer/lib/mixins/template-stamp.js';

--- a/mixins/d2l-sequences-router-mixin.js
+++ b/mixins/d2l-sequences-router-mixin.js
@@ -1,5 +1,5 @@
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { D2LSequencesContentError } from '../components/d2l-sequences-content-error';
+import { D2LSequencesContentError } from '../components/d2l-sequences-content-error.js';
 import '../components/d2l-sequences-content-error.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import { TemplateStamp } from '@polymer/polymer/lib/mixins/template-stamp.js';


### PR DESCRIPTION
This looks like it never worked. Importing the class component allows you to access elements on it.

![image](https://user-images.githubusercontent.com/14796305/85058595-f34ed880-b167-11ea-9f7d-19bdfe6737e5.png)

This is the expected view when there is an error. Previously it would continue to try and show the content you just had, or something. If this file thinks there's an error we should probably show the error page...

![image](https://user-images.githubusercontent.com/14796305/85057924-fd240c00-b166-11ea-867c-8cb022386906.png)
