### PR TITLE
Properly fix activity click issue

### DIFF
--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -253,7 +253,9 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	}
 
 	setCurrent() {
-		this._contentObjectClick();
+		if (!this.isSidebar) {
+			this._contentObjectClick();
+		}
 		this.currentActivity = this.entity && this.entity.getLinkByRel('self').href;
 		this.dispatchEvent(new CustomEvent('sequencenavigator-d2l-activity-link-current-activity', {detail: { href: this.href}}));
 	}

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -178,7 +178,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<div class="d2l-activity-link-title">
 							<a class$="[[completionRequirementClass]]" href="javascript:void(0)" tabindex="-1">
 								[[entity.properties.title]]
-							</a>
+							</div>
 							<d2l-completion-requirement href="[[href]]" token="[[token]]">
 							</d2l-completion-requirement>
 						</div>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -178,7 +178,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<div class="d2l-activity-link-title">
 							<a class$="[[completionRequirementClass]]" href="javascript:void(0)" tabindex="-1">
 								[[entity.properties.title]]
-							</div>
+							</a>
 							<d2l-completion-requirement href="[[href]]" token="[[token]]">
 							</d2l-completion-requirement>
 						</div>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -253,6 +253,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	}
 
 	setCurrent() {
+		this._contentObjectClick();
 		this.currentActivity = this.entity && this.entity.getLinkByRel('self').href;
 		this.dispatchEvent(new CustomEvent('sequencenavigator-d2l-activity-link-current-activity', {detail: { href: this.href}}));
 	}


### PR DESCRIPTION
Merged a fix for fixing activity links that ultimately broke the functionality in sequence launcher. This fixes the issue by adding the missing `_contentObjectClick()` function back in. Initially thought this function was undefined but is part of the `polymer-asv-launch-mixin`, hence why it is not defined in the `d2l-activity-link` component. This also explains the reasoning for why this was initially not an issue in launcher but only in the sequence viewer. This function is the reason the viewer is launched properly.