### PR TITLE
Modify completion check behavior to get (faster) real time updates

### DIFF
--- a/components/d2l-sequences-content-link-mixed.js
+++ b/components/d2l-sequences-content-link-mixed.js
@@ -55,6 +55,11 @@ export class D2LSequencesContentLinkMixed extends D2L.Polymer.Mixins.Sequences.C
 		};
 	}
 
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.startCompletion();
+	}
+
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
 	}

--- a/components/d2l-sequences-content-link-mixed.js
+++ b/components/d2l-sequences-content-link-mixed.js
@@ -55,11 +55,6 @@ export class D2LSequencesContentLinkMixed extends D2L.Polymer.Mixins.Sequences.C
 		};
 	}
 
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this.finishCompletion();
-	}
-
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
 	}

--- a/components/d2l-sequences-content-link-new-tab.js
+++ b/components/d2l-sequences-content-link-new-tab.js
@@ -72,11 +72,6 @@ export class D2LSequencesContentLinkNewTab extends D2L.Polymer.Mixins.Sequences.
 		};
 	}
 
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this.finishCompletion();
-	}
-
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
 	}

--- a/components/d2l-sequences-content-link-new-tab.js
+++ b/components/d2l-sequences-content-link-new-tab.js
@@ -72,6 +72,11 @@ export class D2LSequencesContentLinkNewTab extends D2L.Polymer.Mixins.Sequences.
 		};
 	}
 
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.startCompletion();
+	}
+
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -178,7 +178,7 @@ class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTra
 
 	_onHrefChanged(href, previousHref) {
 		if (previousHref && previousHref !== href && this._previousEntity) {
-			this.finishPreviousEntityCompletion(this._previousEntity);
+			this.startPreviousEntityCompletion(this._previousEntity);
 		}
 	}
 

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -1,26 +1,17 @@
 import '@polymer/polymer/polymer-legacy.js';
-import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import './d2l-sequence-launcher-module.js';
 import '@brightspace-ui-labs/accordion/accordion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import 'siren-entity/siren-entity.js';
-import '../localize-behavior.js';
 import '../mixins/d2l-sequences-completion-tracking-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
 /*
 @memberOf D2L.Polymer.Mixins;
 @mixes SirenEntityMixin
 */
 
-class D2LSequenceLauncherUnit extends mixinBehaviors([
-	D2L.PolymerBehaviors.Siren.EntityBehavior,
-	D2L.Polymer.Mixins.Sequences.CompletionTrackingMixin,
-	D2L.PolymerBehaviors.Sequences.LocalizeBehavior
-],
-PolymerElement
-) {
+class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTrackingMixin() {
 	static get template() {
 		return html`
 		<style>

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -5,6 +5,7 @@ import '@brightspace-ui-labs/accordion/accordion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import 'siren-entity/siren-entity.js';
 import '../localize-behavior.js';
+import '../mixins/d2l-sequences-completion-tracking-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -15,6 +16,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class D2LSequenceLauncherUnit extends mixinBehaviors([
 	D2L.PolymerBehaviors.Siren.EntityBehavior,
+	D2L.Polymer.Mixins.Sequences.CompletionTrackingMixin,
 	D2L.PolymerBehaviors.Sequences.LocalizeBehavior
 ],
 PolymerElement
@@ -122,8 +124,12 @@ PolymerElement
 			dataAsvCssVars: String,
 			href: {
 				type: String,
+				observer: '_onHrefChanged',
 				reflectToAttribute: true,
 				notify: true
+			},
+			_previousEntity: {
+				type: String
 			},
 			role: {
 				type: String
@@ -164,7 +170,8 @@ PolymerElement
 
 	static get observers() {
 		return [
-			'_checkForEarlyLoadEvent(entity, subEntities)'
+			'_checkForEarlyLoadEvent(entity, subEntities)',
+			'_onEntityChanged(entity)'
 		];
 	}
 
@@ -176,6 +183,16 @@ PolymerElement
 		this.updateStyles(
 			styles
 		);
+	}
+
+	_onHrefChanged(href, previousHref) {
+		if (previousHref && previousHref !== href && this._previousEntity) {
+			this.finishPreviousEntityCompletion(this._previousEntity);
+		}
+	}
+
+	_onEntityChanged(entity) {
+		this._previousEntity = entity;
 	}
 
 	_getRootHref(entity) {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -119,9 +119,6 @@ class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTra
 				reflectToAttribute: true,
 				notify: true
 			},
-			_previousEntity: {
-				type: String
-			},
 			role: {
 				type: String
 			},
@@ -161,8 +158,7 @@ class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTra
 
 	static get observers() {
 		return [
-			'_checkForEarlyLoadEvent(entity, subEntities)',
-			'_onEntityChanged(entity)'
+			'_checkForEarlyLoadEvent(entity, subEntities)'
 		];
 	}
 
@@ -177,13 +173,9 @@ class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTra
 	}
 
 	_onHrefChanged(href, previousHref) {
-		if (previousHref && previousHref !== href && this._previousEntity) {
-			this.startPreviousEntityCompletion(this._previousEntity);
+		if (previousHref && previousHref !== href && this.entity) {
+			this.startPreviousEntityCompletion(this.entity);
 		}
-	}
-
-	_onEntityChanged(entity) {
-		this._previousEntity = entity;
 	}
 
 	_getRootHref(entity) {

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -173,6 +173,8 @@ class D2LSequenceLauncherUnit extends D2L.Polymer.Mixins.Sequences.CompletionTra
 	}
 
 	_onHrefChanged(href, previousHref) {
+		// this.entity is the previous entity on href change
+		// since it has not been updated at this point
 		if (previousHref && previousHref !== href && this.entity) {
 			this.startPreviousEntityCompletion(this.entity);
 		}

--- a/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
@@ -13,6 +13,9 @@ function AutomaticCompletionTrackingMixin() {
 				_previousHref: {
 					type: String
 				},
+				_startCompletionCallback: {
+					type: Function
+				},
 				_visibilityChangeCallback: {
 					type: Function
 				}
@@ -25,21 +28,21 @@ function AutomaticCompletionTrackingMixin() {
 
 		ready() {
 			super.ready();
-			this._visibilityChangeCallback = function() {
-				if (document.visibilityState !== 'hidden') {
-					this.startCompletion();
-				}
-			}.bind(this);
+			this._startCompletionCallback = this.startCompletion.bind(this);
 		}
 
 		connectedCallback() {
 			super.connectedCallback();
-			window.addEventListener('visibilitychange', this._visibilityChangeCallback);
+			window.addEventListener('pagehide', this._startCompletionCallback);
+			window.addEventListener('visibilitychange', this._startCompletionCallback);
+			window.addEventListener('beforeunload', this._startCompletionCallback);
 		}
 
 		disconnectedCallback() {
 			super.disconnectedCallback();
-			window.removeEventListener('visibilitychange', this._visibilityChangeCallback);
+			window.removeEventListener('pagehide', this._startCompletionCallback);
+			window.removeEventListener('visibilitychange', this._startCompletionCallback);
+			window.removeEventListener('beforeunload', this._startCompletionCallback);
 		}
 
 		_onHrefChanged(href, previousHref) {

--- a/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
@@ -13,9 +13,6 @@ function AutomaticCompletionTrackingMixin() {
 				_previousHref: {
 					type: String
 				},
-				_finishCompletionCallback: {
-					type: Function
-				},
 				_visibilityChangeCallback: {
 					type: Function
 				}
@@ -28,11 +25,8 @@ function AutomaticCompletionTrackingMixin() {
 
 		ready() {
 			super.ready();
-			this._finishCompletionCallback = this.finishCompletion.bind(this);
 			this._visibilityChangeCallback = function() {
-				if (document.visibilityState === 'hidden') {
-					this._finishCompletionCallback();
-				} else {
+				if (document.visibilityState !== 'hidden') {
 					this.startCompletion();
 				}
 			}.bind(this);
@@ -40,16 +34,12 @@ function AutomaticCompletionTrackingMixin() {
 
 		connectedCallback() {
 			super.connectedCallback();
-			window.addEventListener('pagehide', this._finishCompletionCallback);
 			window.addEventListener('visibilitychange', this._visibilityChangeCallback);
-			window.addEventListener('beforeunload', this._finishCompletionCallback);
 		}
 
 		disconnectedCallback() {
 			super.disconnectedCallback();
-			window.removeEventListener('pagehide', this._finishCompletionCallback);
 			window.removeEventListener('visibilitychange', this._visibilityChangeCallback);
-			window.removeEventListener('beforeunload', this._finishCompletionCallback);
 		}
 
 		_onHrefChanged(href, previousHref) {

--- a/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
@@ -47,7 +47,6 @@ function AutomaticCompletionTrackingMixin() {
 
 		disconnectedCallback() {
 			super.disconnectedCallback();
-			this.finishCompletion();
 			window.removeEventListener('pagehide', this._finishCompletionCallback);
 			window.removeEventListener('visibilitychange', this._visibilityChangeCallback);
 			window.removeEventListener('beforeunload', this._finishCompletionCallback);
@@ -59,7 +58,6 @@ function AutomaticCompletionTrackingMixin() {
 
 		_entityUpdated() {
 			if (this.href !== this._previousHref) {
-				this.finishCompletion();
 				this.startCompletion();
 				this._previousHref = this.href;
 			}

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -5,6 +5,9 @@ import '../localize-behavior.js';
 import { Maybe } from '../maybe.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+const COMPLETION_TRACKING_DELAY = 6000;
+
 function CompletionTrackingMixin() {
 	return class extends mixinBehaviors([
 		D2L.PolymerBehaviors.Siren.EntityBehavior,
@@ -50,7 +53,7 @@ function CompletionTrackingMixin() {
 						this._completionEntity = completion;
 						this._finishCompletion();
 					});
-			}, 6000);
+			}, COMPLETION_TRACKING_DELAY);
 		}
 
 		_finishCompletion() {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -26,7 +26,7 @@ function CompletionTrackingMixin() {
 		}
 
 		startCompletion() {
-			if (this._skipCompletion) {
+			if (!this.entity || this._skipCompletion || this._isComplete(this.entity)) {
 				return;
 			}
 
@@ -39,7 +39,7 @@ function CompletionTrackingMixin() {
 		}
 
 		startPreviousEntityCompletion(previousEntity) {
-			if (!previousEntity || this._skipCompletion) {
+			if (!previousEntity || this._skipCompletion  || this._isComplete(previousEntity)) {
 				return;
 			}
 			// need timeout as items such as quizes, assignments, discussions etc
@@ -52,7 +52,7 @@ function CompletionTrackingMixin() {
 						this._finishCompletion();
 					})
 					.catch(() => {});
-			}, 3000);
+			}, 6000);
 		}
 
 		_finishCompletion() {
@@ -96,6 +96,14 @@ function CompletionTrackingMixin() {
 			} catch (e) {
 				return false;
 			}
+		}
+
+		_isComplete(entity) {
+			const subEntity = entity.getSubEntityByClass('link-activity') || entity.getSubEntityByClass('file-activity');
+			if (!subEntity) {
+				return false;
+			}
+			return !!subEntity.getSubEntityByClass('completed');
 		}
 	};
 }

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -35,19 +35,25 @@ function CompletionTrackingMixin() {
 					this._completionEntity = completion;
 					this._finishCompletion();
 				})
-				.catch(entity => this._failedCompletion = entity);
+				.catch(() => {});
 		}
 
-		finishPreviousEntityCompletion(previousEntity) {
-			this._fireToastEvent(previousEntity);
-
+		startPreviousEntityCompletion(previousEntity) {
 			if (!previousEntity || this._skipCompletion) {
 				return;
 			}
-
-			this._performViewActions(previousEntity, 'finish-view-activity')
-				.then(() => {})
-				.catch(() => {});
+			// need timeout as items such as quizes, assignments, discussions etc
+			// will not appear complete if immediately fetching activity completion information
+			// after navigation to a new item
+			setTimeout(() => {
+				this._performViewActions(previousEntity, 'view-activity-duration')
+					.then(completion => {
+						this._completionEntity = completion;
+						this._fireToastEvent(completion);
+						this._finishCompletion();
+					})
+					.catch(() => {});
+			}, 3000);
 		}
 
 		_finishCompletion() {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -46,7 +46,10 @@ function CompletionTrackingMixin() {
 			}
 
 			this._performViewActions(this.entity, 'view-activity-duration')
-				.then(completion => this._completionEntity = completion)
+				.then(completion => {
+					this._completionEntity = completion;
+					this.finishCompletion();
+				})
 				.catch(entity => this._failedCompletion = entity);
 		}
 

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -49,7 +49,6 @@ function CompletionTrackingMixin() {
 				this._performViewActions(previousEntity, 'view-activity-duration')
 					.then(completion => {
 						this._completionEntity = completion;
-						this._fireToastEvent(completion);
 						this._finishCompletion();
 					})
 					.catch(() => {});
@@ -96,51 +95,6 @@ function CompletionTrackingMixin() {
 					jwt.actualsub !== jwt.sub;
 			} catch (e) {
 				return false;
-			}
-		}
-
-		_fireToastEvent(previousEntity) {
-			const activity = Maybe.of(previousEntity)
-				.map(e => e.getSubEntityByClass('activity'));
-
-			if (activity.isNothing()) {
-				return;
-			}
-
-			const incompleteClass = activity.map(
-				a => a.getSubEntityByClass('incomplete')
-			);
-
-			if (!incompleteClass) {
-				return;
-			}
-
-			const href = activity.chain(
-				a => a.getLinkByRel('about'),
-				a => a.href
-			).value;
-
-			if (!href) {
-				return;
-			}
-
-			const notifyActivityTypes = [
-				'dropbox',
-				'quiz',
-				'discuss'
-			];
-
-			if (notifyActivityTypes.some(t => href.includes(t))) {
-				const event = new CustomEvent('toast', {
-					detail: {
-						message: 'There was more to do in the last activity.',
-						name: previousEntity.properties.title,
-						url: previousEntity.getLinkByRel('self').href
-					},
-					bubbles: true,
-					composed: true,
-				});
-				window.dispatchEvent(event);
 			}
 		}
 	};

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -28,7 +28,20 @@ function CompletionTrackingMixin() {
 			};
 		}
 
-		finishCompletion() {
+		startCompletion() {
+			if (this._skipCompletion) {
+				return;
+			}
+
+			this._performViewActions(this.entity, 'view-activity-duration')
+				.then(completion => {
+					this._completionEntity = completion;
+					this._finishCompletion();
+				})
+				.catch(entity => this._failedCompletion = entity);
+		}
+
+		_finishCompletion() {
 			this._fireToastEvent();
 
 			if (!this._completionEntity || this._skipCompletion) {
@@ -38,19 +51,6 @@ function CompletionTrackingMixin() {
 			this._performViewActions(this._completionEntity, 'finish-view-activity')
 				.then(() => { this._completionEntity = null; })
 				.catch(() => { this._completionEntity = null; });
-		}
-
-		startCompletion() {
-			if (this._skipCompletion) {
-				return;
-			}
-
-			this._performViewActions(this.entity, 'view-activity-duration')
-				.then(completion => {
-					this._completionEntity = completion;
-					this.finishCompletion();
-				})
-				.catch(entity => this._failedCompletion = entity);
 		}
 
 		_performViewActions(entity, actionName) {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -44,13 +44,30 @@ function CompletionTrackingMixin() {
 		_finishCompletion() {
 			this._fireToastEvent();
 
-			if (!this._completionEntity || this._skipCompletion) {
+			if (!this._completionEntity || this._skipCompletion || !this._hasCompletionStatus(this._completionEntity)) {
 				return;
 			}
 
 			this._performViewActions(this._completionEntity, 'finish-view-activity')
 				.then(() => { this._completionEntity = null; })
 				.catch(() => { this._completionEntity = null; });
+		}
+
+		_hasCompletionStatus(activity) {
+			if (!activity) {
+				return false;
+			}
+			const subEntity = activity.getSubEntityByClass('link-activity') || activity.getSubEntityByClass('file-activity');
+			if (!subEntity) {
+				return false;
+			}
+			const completionClass = subEntity.getSubEntityByClass('completion');
+			if (!completionClass) {
+				false;
+			}
+			return completionClass.hasClass('completed')
+				? true
+				: false;
 		}
 
 		_performViewActions(entity, actionName) {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -41,7 +41,7 @@ function CompletionTrackingMixin() {
 		}
 
 		startPreviousEntityCompletion(previousEntity) {
-			if (!previousEntity || this._skipCompletion  || this._isComplete(previousEntity)) {
+			if (!previousEntity || this._skipCompletion) {
 				return;
 			}
 			// need timeout as items such as quizes, assignments, discussions etc

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -41,33 +41,28 @@ function CompletionTrackingMixin() {
 				.catch(entity => this._failedCompletion = entity);
 		}
 
+		finishPreviousEntityCompletion(previousEntity) {
+			this._fireToastEvent();
+
+			if (!previousEntity || this._skipCompletion) {
+				return;
+			}
+
+			this._performViewActions(previousEntity, 'finish-view-activity')
+				.then(() => {})
+				.catch(() => {});
+		}
+
 		_finishCompletion() {
 			this._fireToastEvent();
 
-			if (!this._completionEntity || this._skipCompletion || !this._hasCompletionStatus(this._completionEntity)) {
+			if (!this._completionEntity || this._skipCompletion) {
 				return;
 			}
 
 			this._performViewActions(this._completionEntity, 'finish-view-activity')
 				.then(() => { this._completionEntity = null; })
 				.catch(() => { this._completionEntity = null; });
-		}
-
-		_hasCompletionStatus(activity) {
-			if (!activity) {
-				return false;
-			}
-			const subEntity = activity.getSubEntityByClass('link-activity') || activity.getSubEntityByClass('file-activity');
-			if (!subEntity) {
-				return false;
-			}
-			const completionClass = subEntity.getSubEntityByClass('completion');
-			if (!completionClass) {
-				false;
-			}
-			return completionClass.hasClass('completed')
-				? true
-				: false;
 		}
 
 		_performViewActions(entity, actionName) {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -34,8 +34,7 @@ function CompletionTrackingMixin() {
 				.then(completion => {
 					this._completionEntity = completion;
 					this._finishCompletion();
-				})
-				.catch(() => {});
+				});
 		}
 
 		startPreviousEntityCompletion(previousEntity) {
@@ -50,8 +49,7 @@ function CompletionTrackingMixin() {
 					.then(completion => {
 						this._completionEntity = completion;
 						this._finishCompletion();
-					})
-					.catch(() => {});
+					});
 			}, 6000);
 		}
 
@@ -61,8 +59,7 @@ function CompletionTrackingMixin() {
 			}
 
 			this._performViewActions(this._completionEntity, 'finish-view-activity')
-				.then(() => { this._completionEntity = null; })
-				.catch(() => { this._completionEntity = null; });
+				.then(() => { this._completionEntity = null; });
 		}
 
 		_performViewActions(entity, actionName) {

--- a/test/d2l-sequences-automatic-completion-tracking-mixin.html
+++ b/test/d2l-sequences-automatic-completion-tracking-mixin.html
@@ -44,12 +44,10 @@ describe('d2l-sequences-automatic-completion-tracking-mixin', () => {
 		element = fixture('MixinFixture');
 	});
 
-	it('startCompletion and finishCompletion must be called when element is updated', async() => {
+	it('startCompletion must be called when element is updated', async() => {
 		const startCompletion = sinon.stub(element, 'startCompletion', () => {});
-		const finishCompletion = sinon.stub(element, 'finishCompletion', () => {});
 		await SirenFixture('data/activity-completion-all.json', element);
 		expect(startCompletion).to.have.been.called;
-		expect(finishCompletion).to.have.been.called;
 	});
 });
 </script>

--- a/test/d2l-sequences-completion-tracking-mixin.html
+++ b/test/d2l-sequences-completion-tracking-mixin.html
@@ -94,7 +94,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 			sub: 175,
 			actualsub: 169
 		});
-		element.finishCompletion();
+		element._finishCompletion();
 
 		expect(performViewActions).not.to.have.been.called;
 	});
@@ -104,7 +104,7 @@ describe('d2l-sequences-completion-tracking-mixin', () => {
 
 		await SirenFixture('data/activity-completion-all.json', element);
 		element._completionEntity = element.entity;
-		element.finishCompletion();
+		element._finishCompletion();
 
 		expect(performSirenAction).to.have.been.calledWithMatch({
 			name: 'finish-view-activity',


### PR DESCRIPTION
Previously completion check only occurred upon navigating to a new item in the nav bar (or through arrow buttons). This didn't allow us to update completion count or completion status in a more real-time manner. For example, when viewing HTML topics, they are considered complete just after viewing them. This means we can update completion count and status immediately after opening the link. However, some items like discussion, assignments, surveys etc. shouldn't be polled for up updates until navigating out of the item since we have no way of knowing when a user has completed the activity. The code changes below account for these scenarios and try to better update completion count in a more real-time manner.

Gif below shows immediate completion count updates on items that are marked as complete on view.
![completion-count](https://user-images.githubusercontent.com/64804046/87077380-05fd8000-c1f1-11ea-865c-d908d24964ff.gif)
