### PR TITLE
Revert d2l_video bump

### DIFF
--- a/components/d2l-sequences-content-video.js
+++ b/components/d2l-sequences-content-video.js
@@ -1,13 +1,13 @@
-import '@d2l/video/d2l-video.js';
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import '@d2l/video/d2l-video.js';
 export class D2LSequencesContentVideo extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
 	static get template() {
 		return html`
 		<style>
 			d2l-video {
 				width: 100%;
-				max-height: calc(100% - 12px);
+				height: calc(100% - 12px);
 				overflow: hidden;
 			}
 		</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,19 +160,17 @@
       "integrity": "sha512-mstURrd8MYKEOjOG3tDiemmHS9iOc4Yr33Ojh39qFYbeMeD1OKuDvQokLuhz10eukUt1pdfu1aqy5zrO98qErA=="
     },
     "@d2l/audio": {
-      "version": "github:Brightspace/d2l-audio#c34745a160fcce5835ce1fd7de0212dfecc92247",
+      "version": "github:Brightspace/d2l-audio#d566da4e1ecf530314b93c6cf0f97a40c47f1efd",
       "from": "github:Brightspace/d2l-audio#semver:^3",
       "requires": {
+        "@brightspace-ui/core": "^1.53.0",
         "@d2l/media-behavior": "github:Brightspace/d2l-media-behavior#semver:^1",
         "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
         "@polymer/iron-a11y-keys-behavior": "^3.0.0",
         "@polymer/iron-flex-layout": "^3.0.0",
         "@polymer/iron-range-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2"
       }
     },
     "@d2l/media-behavior": {
@@ -2038,7 +2036,7 @@
       }
     },
     "d2l-loading-spinner": {
-      "version": "github:BrightspaceUI/loading-spinner#05ed2ed48301af042bff90fcd093fb25b69f53ae",
+      "version": "github:BrightspaceUI/loading-spinner#f4cb4872634f9be4a1bb4966320f45c3a98baabd",
       "from": "github:BrightspaceUI/loading-spinner#semver:^7",
       "requires": {
         "@brightspace-ui/core": "^1.17.0",
@@ -2046,7 +2044,7 @@
       }
     },
     "d2l-localize-behavior": {
-      "version": "github:BrightspaceUI/localize-behavior#8c9497de0499f14e260f9c450a177636f26dce86",
+      "version": "github:BrightspaceUI/localize-behavior#3257e7533197d29636eaf43be599f054df0fbd46",
       "from": "github:BrightspaceUI/localize-behavior#semver:^2",
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -2056,7 +2054,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#927b5d07ce25f31a603e50d8bb9195a540489c2f",
+      "version": "github:BrightspaceUI/navigation#6a9e5fe0908cfcfef46cfcd3106f414af21b07df",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -2109,7 +2107,7 @@
       }
     },
     "d2l-polymer-siren-behaviors": {
-      "version": "github:Brightspace/polymer-siren-behaviors#9bc765ab8f130a980fd7d947f7925c2eea5bd2f4",
+      "version": "github:Brightspace/polymer-siren-behaviors#87505ec23b8a0249fccbdf8c8e17720a3e0cdfd0",
       "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "requires": {
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
@@ -2138,7 +2136,7 @@
       }
     },
     "d2l-typography": {
-      "version": "github:BrightspaceUI/typography#be1b7ca350de8fcd640ae1163e8647dc5584f539",
+      "version": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
       "from": "github:BrightspaceUI/typography#semver:^7",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -21081,7 +21079,7 @@
       }
     },
     "polymer-google-drive-viewer": {
-      "version": "github:Brightspace/polymer-google-drive-viewer#aecd5eeec7e72ca32a0cf614a5c0e99894d29136",
+      "version": "github:Brightspace/polymer-google-drive-viewer#d752b3c68dffd494922e148abb20aff67cd35225",
       "from": "github:Brightspace/polymer-google-drive-viewer#semver:^3",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -21855,7 +21853,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#bc5ac969e260fa604ff9eab9ad6fa17140f7307d",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#5d0e59242e2c675263ae962105ca1a8d9a20f17e",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -160,17 +160,19 @@
       "integrity": "sha512-mstURrd8MYKEOjOG3tDiemmHS9iOc4Yr33Ojh39qFYbeMeD1OKuDvQokLuhz10eukUt1pdfu1aqy5zrO98qErA=="
     },
     "@d2l/audio": {
-      "version": "github:Brightspace/d2l-audio#d566da4e1ecf530314b93c6cf0f97a40c47f1efd",
+      "version": "github:Brightspace/d2l-audio#c34745a160fcce5835ce1fd7de0212dfecc92247",
       "from": "github:Brightspace/d2l-audio#semver:^3",
       "requires": {
-        "@brightspace-ui/core": "^1.53.0",
         "@d2l/media-behavior": "github:Brightspace/d2l-media-behavior#semver:^1",
         "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
         "@polymer/iron-a11y-keys-behavior": "^3.0.0",
         "@polymer/iron-flex-layout": "^3.0.0",
         "@polymer/iron-range-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2"
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "@d2l/media-behavior": {
@@ -194,17 +196,21 @@
       }
     },
     "@d2l/video": {
-      "version": "github:Brightspace/d2l-video#73202d074c0e32ce7d9532bd330a8baf477c99eb",
-      "from": "github:Brightspace/d2l-video#semver:^2",
+      "version": "github:Brightspace/d2l-video#c3a0518ec3dfb70c89f93e778a88c6ce7da18dfb",
+      "from": "github:Brightspace/d2l-video#semver:^1",
       "requires": {
-        "@brightspace-ui/core": "^1.53.0",
         "@d2l/media-behavior": "github:Brightspace/d2l-media-behavior#semver:^1",
         "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
         "@polymer/iron-flex-layout": "^3.0.0-pre.18",
         "@polymer/iron-range-behavior": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
+        "d2l-button": "github:BrightspaceUI/button#semver:^5",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fullscreen-api": "github:Brightspace/fullscreen-api#semver:^3"
       }
     },
@@ -2032,7 +2038,7 @@
       }
     },
     "d2l-loading-spinner": {
-      "version": "github:BrightspaceUI/loading-spinner#f4cb4872634f9be4a1bb4966320f45c3a98baabd",
+      "version": "github:BrightspaceUI/loading-spinner#05ed2ed48301af042bff90fcd093fb25b69f53ae",
       "from": "github:BrightspaceUI/loading-spinner#semver:^7",
       "requires": {
         "@brightspace-ui/core": "^1.17.0",
@@ -2040,7 +2046,7 @@
       }
     },
     "d2l-localize-behavior": {
-      "version": "github:BrightspaceUI/localize-behavior#3257e7533197d29636eaf43be599f054df0fbd46",
+      "version": "github:BrightspaceUI/localize-behavior#8c9497de0499f14e260f9c450a177636f26dce86",
       "from": "github:BrightspaceUI/localize-behavior#semver:^2",
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -2050,7 +2056,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#6a9e5fe0908cfcfef46cfcd3106f414af21b07df",
+      "version": "github:BrightspaceUI/navigation#927b5d07ce25f31a603e50d8bb9195a540489c2f",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -2103,7 +2109,7 @@
       }
     },
     "d2l-polymer-siren-behaviors": {
-      "version": "github:Brightspace/polymer-siren-behaviors#87505ec23b8a0249fccbdf8c8e17720a3e0cdfd0",
+      "version": "github:Brightspace/polymer-siren-behaviors#9bc765ab8f130a980fd7d947f7925c2eea5bd2f4",
       "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
       "requires": {
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
@@ -2132,7 +2138,7 @@
       }
     },
     "d2l-typography": {
-      "version": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
+      "version": "github:BrightspaceUI/typography#be1b7ca350de8fcd640ae1163e8647dc5584f539",
       "from": "github:BrightspaceUI/typography#semver:^7",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -21075,7 +21081,7 @@
       }
     },
     "polymer-google-drive-viewer": {
-      "version": "github:Brightspace/polymer-google-drive-viewer#d752b3c68dffd494922e148abb20aff67cd35225",
+      "version": "github:Brightspace/polymer-google-drive-viewer#aecd5eeec7e72ca32a0cf614a5c0e99894d29136",
       "from": "github:Brightspace/polymer-google-drive-viewer#semver:^3",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -21849,7 +21855,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#5d0e59242e2c675263ae962105ca1a8d9a20f17e",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#bc5ac969e260fa604ff9eab9ad6fa17140f7307d",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@brightspace-ui-labs/accordion": "^2.3.0",
     "@brightspace-ui/core": "^1",
     "@d2l/audio": "Brightspace/d2l-audio#semver:^3",
-    "@d2l/video": "Brightspace/d2l-video#semver:^2",
+    "@d2l/video": "Brightspace/d2l-video#semver:^1",
     "@polymer/iron-a11y-announcer": "^3.1.0",
     "@polymer/iron-collapse": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",


### PR DESCRIPTION
Pulling the d2l_video changes out of the August release, I'll throw another PR up shortly that we can merge after branching 

This reverts https://github.com/BrightspaceHypermediaComponents/sequences/pull/245