### PR TITLE
US118394 revert the revert - re-update d2l-video

### DIFF
--- a/components/d2l-sequences-content-video.js
+++ b/components/d2l-sequences-content-video.js
@@ -1,13 +1,13 @@
+import '@d2l/video/d2l-video.js';
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import '@d2l/video/d2l-video.js';
 export class D2LSequencesContentVideo extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
 	static get template() {
 		return html`
 		<style>
 			d2l-video {
 				width: 100%;
-				height: calc(100% - 12px);
+				max-height: calc(100% - 12px);
 				overflow: hidden;
 			}
 		</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -194,21 +194,17 @@
       }
     },
     "@d2l/video": {
-      "version": "github:Brightspace/d2l-video#c3a0518ec3dfb70c89f93e778a88c6ce7da18dfb",
-      "from": "github:Brightspace/d2l-video#semver:^1",
+      "version": "github:Brightspace/d2l-video#73202d074c0e32ce7d9532bd330a8baf477c99eb",
+      "from": "github:Brightspace/d2l-video#semver:^2",
       "requires": {
+        "@brightspace-ui/core": "^1.53.0",
         "@d2l/media-behavior": "github:Brightspace/d2l-media-behavior#semver:^1",
         "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
         "@polymer/iron-flex-layout": "^3.0.0-pre.18",
         "@polymer/iron-range-behavior": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0",
-        "d2l-button": "github:BrightspaceUI/button#semver:^5",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "fullscreen-api": "github:Brightspace/fullscreen-api#semver:^3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@brightspace-ui-labs/accordion": "^2.3.0",
     "@brightspace-ui/core": "^1",
     "@d2l/audio": "Brightspace/d2l-audio#semver:^3",
-    "@d2l/video": "Brightspace/d2l-video#semver:^1",
+    "@d2l/video": "Brightspace/d2l-video#semver:^2",
     "@polymer/iron-a11y-announcer": "^3.1.0",
     "@polymer/iron-collapse": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0",


### PR DESCRIPTION
We want to ship the updated d2l-video component in the **September** release (not August). This should be merged **after 20.20.8 branching**.

Re-adds back in https://github.com/BrightspaceHypermediaComponents/sequences/pull/245