### PR TITLE
Cprajapati/de39648

### DIFF
--- a/components/d2l-sequences-content-image.js
+++ b/components/d2l-sequences-content-image.js
@@ -1,0 +1,56 @@
+import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+export class D2LSequencesContentImage extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
+	static get template() {
+		return html`
+		<style>
+		    img {
+                max-width: 100%;
+                height: auto;
+			}
+		</style>
+		<div>
+            <img src="[[_fileLocation]]">
+		</div>
+`;
+	}
+
+	static get is() {
+		return 'd2l-sequences-content-image';
+	}
+	static get properties() {
+		return {
+			href: {
+				type: String,
+				reflectToAttribute: true,
+				notify: true,
+				observer: '_scrollToTop'
+			},
+			_fileLocation: {
+				type: String,
+				computed: '_getFileLocation(entity)'
+			},
+			title: {
+				type: String,
+				computed: '_getTitle(entity)'
+			},
+		};
+	}
+	_scrollToTop() {
+		window.top.scrollTo(0, 0);
+	}
+	_getFileLocation(entity) {
+		try {
+			const fileActivity = entity.getSubEntityByClass('file-activity');
+			const file = fileActivity.getSubEntityByClass('file');
+			const link = file.getLinkByClass('pdf') || file.getLinkByClass('embed') || file.getLinkByRel('alternate');
+			return link.href;
+		} catch (e) {
+			return '';
+		}
+	}
+	_getTitle(entity) {
+		return entity && entity.properties && entity.properties.title || '';
+	}
+}
+customElements.define(D2LSequencesContentImage.is, D2LSequencesContentImage);

--- a/components/d2l-sequences-content-image.js
+++ b/components/d2l-sequences-content-image.js
@@ -1,5 +1,6 @@
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
 export class D2LSequencesContentImage extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
 	static get template() {
 		return html`
@@ -9,9 +10,7 @@ export class D2LSequencesContentImage extends D2L.Polymer.Mixins.Sequences.Autom
                 height: auto;
 			}
 		</style>
-		<div>
-            <img src="[[_fileLocation]]">
-		</div>
+		<img src="[[_fileLocation]]">
 `;
 	}
 
@@ -29,28 +28,21 @@ export class D2LSequencesContentImage extends D2L.Polymer.Mixins.Sequences.Autom
 			_fileLocation: {
 				type: String,
 				computed: '_getFileLocation(entity)'
-			},
-			title: {
-				type: String,
-				computed: '_getTitle(entity)'
-			},
+			}
 		};
 	}
 	_scrollToTop() {
 		window.top.scrollTo(0, 0);
 	}
 	_getFileLocation(entity) {
-		try {
+		if (entity) {
 			const fileActivity = entity.getSubEntityByClass('file-activity');
 			const file = fileActivity.getSubEntityByClass('file');
-			const link = file.getLinkByClass('pdf') || file.getLinkByClass('embed') || file.getLinkByRel('alternate');
+			const link = file.getLinkByClass('embed') || file.getLinkByRel('alternate');
 			return link.href;
-		} catch (e) {
+		} else {
 			return '';
 		}
-	}
-	_getTitle(entity) {
-		return entity && entity.properties && entity.properties.title || '';
 	}
 }
 customElements.define(D2LSequencesContentImage.is, D2LSequencesContentImage);

--- a/components/d2l-sequences-content-router.js
+++ b/components/d2l-sequences-content-router.js
@@ -5,6 +5,7 @@ import { D2LSequencesContentFileHtml } from './d2l-sequences-content-file-html.j
 import { D2LSequencesContentFilePdf } from './d2l-sequences-content-file-pdf.js';
 import { D2LSequencesContentVideo } from './d2l-sequences-content-video';
 import { D2LSequencesContentAudio } from './d2l-sequences-content-audio';
+import { D2LSequencesContentImage } from './d2l-sequences-content-image';
 import './d2l-sequences-content-file-html.js';
 import { D2LSequencesContentLinkMixed } from './d2l-sequences-content-link-mixed.js';
 import { D2LSequencesContentLinkNewTab } from './d2l-sequences-content-link-new-tab';
@@ -46,11 +47,11 @@ class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin
 			['audio/ogg', D2LSequencesContentAudio.is],
 			['audio/aac', D2LSequencesContentAudio.is],
 			['audio/wave', D2LSequencesContentAudio.is],
-			['image/bmp', D2LSequencesContentFileHtml.is],
-			['image/gif', D2LSequencesContentFileHtml.is],
-			['image/jpeg', D2LSequencesContentFileHtml.is],
-			['image/png', D2LSequencesContentFileHtml.is],
-			['image/svg+xml', D2LSequencesContentFileHtml.is],
+			['image/bmp', D2LSequencesContentImage.is],
+			['image/gif', D2LSequencesContentImage.is],
+			['image/jpeg', D2LSequencesContentImage.is],
+			['image/png', D2LSequencesContentImage.is],
+			['image/svg+xml', D2LSequencesContentImage.is],
 			['text/html', D2LSequencesContentFileHtml.is]
 		]);
 	}

--- a/test/d2l-sequences-content-router.html
+++ b/test/d2l-sequences-content-router.html
@@ -17,6 +17,7 @@
 import loadFileWithDelay from './loadFileWithDelay.js';
 import '../components/d2l-sequences-content-router.js';
 import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
+import { D2LSequencesContentImage } from '../components/d2l-sequences-content-image.js';
 import { D2LSequencesContentFilePdf } from '../components/d2l-sequences-content-file-pdf.js';
 import { D2LSequencesContentFileDownload } from '../components/d2l-sequences-content-file-download.js';
 import { D2LSequencesContentLink } from '../components/d2l-sequences-content-link';
@@ -33,22 +34,22 @@ describe('d2l-sequences-content-router', () => {
 
 		it('image/bmp', async() => {
 			const element = await loadFileWithDelay('data/activity-file-bmp.json');
-			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentImage.is)).to.exist;
 		});
 
 		it('should handle image/gif', async() => {
 			const element = await loadFileWithDelay('data/activity-file-gif.json');
-			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentImage.is)).to.exist;
 		});
 
 		it('should handle image/jpeg', async() => {
 			const element = await loadFileWithDelay('data/activity-file-jpeg.json');
-			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentImage.is)).to.exist;
 		});
 
 		it('should handle image/png', async() => {
 			const element = await loadFileWithDelay('data/activity-file-png.json');
-			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentImage.is)).to.exist;
 		});
 
 		it('should handle doc converted files', async() => {
@@ -58,7 +59,7 @@ describe('d2l-sequences-content-router', () => {
 
 		it('should handle image/svg+xml', async() => {
 			const element = await loadFileWithDelay('data/activity-file-svg.json');
-			expect(element.shadowRoot.querySelector(D2LSequencesContentFileHtml.is)).to.exist;
+			expect(element.shadowRoot.querySelector(D2LSequencesContentImage.is)).to.exist;
 		});
 
 		it('text/html', async() => {


### PR DESCRIPTION
This PR includes changes that make images render responsively in LX. This was in response to: [DE39648](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F400766093372), where larger images led to scrollbars being shown and the images not being rendered within the view window. 

This was because the images were being rendered in an iframe.. 😞 

The new component, D2LSequencesContentImage, simply loads the image in a div and using the img tag.

Before:
![Before](https://user-images.githubusercontent.com/29843252/88111390-756d5b00-cb73-11ea-936d-d5064617ed13.png)

After:
![After](https://user-images.githubusercontent.com/29843252/88111409-7a320f00-cb73-11ea-8e59-29b76ee12f64.PNG)
