### PR TITLE
DE39748: Make (large) image responsively fit screen, i.e. vertically as well i…

### DIFF
--- a/components/d2l-sequences-content-image.js
+++ b/components/d2l-sequences-content-image.js
@@ -6,8 +6,10 @@ export class D2LSequencesContentImage extends D2L.Polymer.Mixins.Sequences.Autom
 		return html`
 		<style>
 		    img {
+				display: block;
+				margin: auto;
                 max-width: 100%;
-                height: auto;
+                max-height: 100%;
 			}
 		</style>
 		<img src="[[_fileLocation]]">


### PR DESCRIPTION
The previous change I had made, made it so large images would scale down to fit horizontally but not vertically. The expected case is for the image to scale down vertically as well.

This has been achieved by making the max-height property to also have the value of 100%, in addition, margin: auto makes the image center horizontally and display: block makes it so the image fits and no scroll bars are visible.

Before:
![Before-01](https://user-images.githubusercontent.com/29843252/88856387-02d72d80-d1ba-11ea-8afd-3c0a2b1bbc05.PNG)

After:
![After-01](https://user-images.githubusercontent.com/29843252/88856408-0b2f6880-d1ba-11ea-95e4-cc5b1ac2afee.PNG)
