### PR TITLE
Fix side nav skeleton issue

### DIFF
--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-module.js
@@ -440,7 +440,7 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 	static get observers() {
 		return [
 			'_openModule(_moduleStartOpen)',
-			'_checkForEarlyLoadEvent(entity, subEntities, _moduleStartOpen)'
+			'_checkForEarlyLoadEvent(entity, subEntities, _moduleStartOpen)',
 		];
 	}
 
@@ -665,9 +665,13 @@ class D2LSequenceLauncherModule extends PolymerASVLaunchMixin(CompletionStatusMi
 		}
 
 		return subEntities.reduce((acc, { href }) => {
+			let hasLoaded = false;
+			if (this._childrenLoadingTracker && this._childrenLoadingTracker[href]) {
+				hasLoaded = this._childrenLoadingTracker[href];
+			}
 			return {
 				...acc,
-				[href]: false
+				[href]: hasLoaded
 			};
 		}, {});
 	}

--- a/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
+++ b/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js
@@ -218,9 +218,13 @@ PolymerElement
 		}
 
 		return subEntities.reduce((acc, { href }) => {
+			let hasLoaded = false;
+			if (this._childrenLoadingTracker && this._childrenLoadingTracker[href]) {
+				hasLoaded = this._childrenLoadingTracker[href];
+			}
 			return {
 				...acc,
-				[href]: false
+				[href]: hasLoaded
 			};
 		}, {});
 	}

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -282,9 +282,13 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		}
 
 		return subEntities.reduce((acc, { href }) => {
+			let hasLoaded = false;
+			if (this._childrenLoadingTracker && this._childrenLoadingTracker[href]) {
+				hasLoaded = this._childrenLoadingTracker[href];
+			}
 			return {
 				...acc,
-				[href]: false
+				[href]: hasLoaded
 			};
 		}, {});
 	}


### PR DESCRIPTION
Issue is that `entity` is being updated more in the front-end as (I assume) a result of me fetching parent entity updates when viewing activity items in the side nav. This likely has downstream effects in the entity store causing entities to be updated in 
- `d2l-sequence-launcher-unit`
- `d2l-sequence-launcher-module`
- `d2l-inner-module`

Essentially when the entity updates, it refreshes the `subEntities` prop which then resets the `_childrenLoadingTracker`. Resetting this tracker basically makes us lose all child loading tracking information prior to the entity update as these events are fired asynchronously. To keep track of children load events amidst entity updates we now keep track of the previous load state instead of removing it altogether.