### PR TITLE
Move scroll bar on HTML activities to far right

### DIFF
--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -1,24 +1,31 @@
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
+import { VIEWER_MAX_WIDTH, VIEWER_HORIZONTAL_MARGIN } from '../util/constants';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
 	static get template() {
 		return html`
-		<style>
-			.d2l-sequences-scroll-container {
-				-webkit-overflow-scrolling: touch;
-				overflow-y: auto;
-				height: 100%;
-			}
-			iframe {
-				width: 100%;
-				height: calc(100% - 12px);
-				overflow: hidden;
-			}
-		</style>
-		<div class="d2l-sequences-scroll-container">
-			<iframe id="content" frameborder="0" src$="[[_fileLocation]]" title$="[[title]]" allowfullscreen allow="microphone *; camera *; display-capture *; encrypted-media *;"></iframe>
-		</div>
-`;
+			<style>
+				.d2l-sequences-content-container {
+					height: 100%;
+				}
+				iframe {
+					width: 100%;
+					height: calc(100% - 12px);
+					overflow: hidden;
+				}
+			</style>
+			<div class="d2l-sequences-content-container">
+				<iframe
+					id="content"
+					on-load="_setIframeStyles"
+					frameborder="0"
+					src$="[[_fileLocation]]"
+					title$="[[title]]"
+					allowfullscreen
+					allow="microphone *; camera *; display-capture *; encrypted-media *;"
+				></iframe>
+			</div>
+		`;
 	}
 
 	static get is() {
@@ -57,6 +64,13 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-sequence-viewer-multipage-navigation', this._navigateMultiPageFileListener);
 		window.postMessage(JSON.stringify({ handler: 'd2l.nav.reset' }), '*');
+	}
+
+	_setIframeStyles() {
+		const htmlIframe = this.$.content;
+		const maxWidth = VIEWER_MAX_WIDTH + (2 * VIEWER_HORIZONTAL_MARGIN);
+		htmlIframe.contentDocument.body.style.maxWidth = `${maxWidth}px`;
+		htmlIframe.contentDocument.body.style.margin = '0 auto';
 	}
 
 	_scrollToTop() {

--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -71,6 +71,7 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 		const maxWidth = VIEWER_MAX_WIDTH + (2 * VIEWER_HORIZONTAL_MARGIN);
 		htmlIframe.contentDocument.body.style.maxWidth = `${maxWidth}px`;
 		htmlIframe.contentDocument.body.style.margin = '0 auto';
+		htmlIframe.contentDocument.body.style.padding = `0 ${VIEWER_HORIZONTAL_MARGIN}px`;
 	}
 
 	_scrollToTop() {

--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -6,6 +6,8 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 		return html`
 			<style>
 				.d2l-sequences-content-container {
+					-webkit-overflow-scrolling: touch;
+					overflow-y: auto;
 					height: 100%;
 				}
 				iframe {

--- a/components/d2l-sequences-content-router.js
+++ b/components/d2l-sequences-content-router.js
@@ -63,7 +63,7 @@ class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin
 }
 customElements.define(D2LSequencesContentRouter.is, D2LSequencesContentRouter);
 
-function getEntityType(entity) {
+export function getEntityType(entity) {
 	if (!entity || !entity.entities) {
 		return D2LSequencesContentUnknown.is;
 	}

--- a/components/d2l-sequences-content-router.js
+++ b/components/d2l-sequences-content-router.js
@@ -1,26 +1,8 @@
 import '../mixins/d2l-sequences-router-mixin.js';
-import { D2LSequencesContentEoLMain } from './d2l-sequences-content-eol-main.js';
-import './d2l-sequences-content-file-download.js';
-import { D2LSequencesContentFileHtml } from './d2l-sequences-content-file-html.js';
-import { D2LSequencesContentFilePdf } from './d2l-sequences-content-file-pdf.js';
-import { D2LSequencesContentVideo } from './d2l-sequences-content-video';
-import { D2LSequencesContentAudio } from './d2l-sequences-content-audio';
-import { D2LSequencesContentImage } from './d2l-sequences-content-image';
-import './d2l-sequences-content-file-html.js';
-import { D2LSequencesContentLinkMixed } from './d2l-sequences-content-link-mixed.js';
-import { D2LSequencesContentLinkNewTab } from './d2l-sequences-content-link-new-tab';
-import { D2LSequencesContentLinkScorm } from './d2l-sequences-content-link-scorm.js';
-import { D2LSequencesContentLinkOnedrive } from './d2l-sequences-content-link-onedrive.js';
-import { D2LSequencesContentLinkGoogledrive } from './d2l-sequences-content-link-googledrive.js';
-import { D2LSequencesContentLink } from './d2l-sequences-content-link.js';
-import { D2LSequencesContentUnknown } from './d2l-sequences-content-unknown.js';
-import { D2LSequencesContentFileProcessing } from './d2l-sequences-content-file-processing';
-import { D2LSequencesContentModule } from './d2l-sequences-content-module.js';
+import EntityTypeHelper from '../helpers/entity-type-helper.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { D2LSequencesContentContentServiceLink } from './d2l-sequences-content-content-service-link.js';
-import { D2LSequencesContentFileDownload } from './d2l-sequences-content-file-download';
 
-class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin(getEntityType) {
+class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin(EntityTypeHelper.getEntityType) {
 	static get template() {
 		return html``;
 	}
@@ -28,108 +10,6 @@ class D2LSequencesContentRouter extends D2L.Polymer.Mixins.Sequences.RouterMixin
 	static get is() {
 		return 'd2l-sequences-content-router';
 	}
-	static get fileActivity() {
-		return 'file-activity';
-	}
-	static get fileUnknown() {
-		return D2LSequencesContentFileDownload.is;
-	}
-	static get fileProcessing() {
-		return D2LSequencesContentFileProcessing.is;
-	}
-	static get linkActivity() {
-		return 'link-activity';
-	}
-	static get mimeType() {
-		return new Map([
-			['application/pdf', D2LSequencesContentFilePdf.is],
-			['video/mp4', D2LSequencesContentVideo.is],
-			['video/ogg', D2LSequencesContentVideo.is],
-			['video/webm', D2LSequencesContentVideo.is],
-			['audio/webm', D2LSequencesContentVideo.is],
-			['audio/flac', D2LSequencesContentAudio.is],
-			['audio/mp3', D2LSequencesContentAudio.is],
-			['audio/ogg', D2LSequencesContentAudio.is],
-			['audio/aac', D2LSequencesContentAudio.is],
-			['audio/wave', D2LSequencesContentAudio.is],
-			['image/bmp', D2LSequencesContentImage.is],
-			['image/gif', D2LSequencesContentImage.is],
-			['image/jpeg', D2LSequencesContentImage.is],
-			['image/png', D2LSequencesContentImage.is],
-			['image/svg+xml', D2LSequencesContentImage.is],
-			['text/html', D2LSequencesContentFileHtml.is]
-		]);
-	}
 }
 customElements.define(D2LSequencesContentRouter.is, D2LSequencesContentRouter);
-
-export function getEntityType(entity) {
-	if (!entity || !entity.entities) {
-		return D2LSequencesContentUnknown.is;
-	}
-
-	if (entity.class.includes(D2LSequencesContentEoLMain.eolClass)) {
-		return D2LSequencesContentEoLMain.is;
-	}
-
-	if (entity.class.includes(D2LSequencesContentModule.contentModuleClass)) {
-		return D2LSequencesContentModule.is;
-	}
-
-	for (let i = 0; i < entity.entities.length; i++) {
-		const subEntity = entity.entities[i];
-		// hypermedia classes tend to be more specific at the end of the array
-		for (let j = subEntity.class.length - 1; j >= 0; --j) {
-			switch (subEntity.class[j]) {
-				case D2LSequencesContentLinkOnedrive.contentClass:
-					return D2LSequencesContentLinkOnedrive.is;
-				case D2LSequencesContentLinkGoogledrive.contentClass:
-					return D2LSequencesContentLinkGoogledrive.is;
-				case D2LSequencesContentRouter.fileActivity:
-					return getFileEntityType(subEntity);
-				case D2LSequencesContentRouter.linkActivity:
-					return getLinkEntityType(subEntity);
-				case D2LSequencesContentLinkScorm.contentClass:
-					return subEntity.hasClass('open-in-new-tab') ? D2LSequencesContentLinkScorm.is : D2LSequencesContentContentServiceLink.is;
-				case 'link-scorm-2004':
-					return D2LSequencesContentLinkScorm.is;
-				case 'link-scorm-1-2':
-					return D2LSequencesContentLinkScorm.is;
-			}
-		}
-	}
-	return D2LSequencesContentUnknown.is;
-}
-
-function getFileEntityType(fileActivity) {
-	const file = fileActivity.getSubEntityByClass('file');
-	let mimeType = file && file.properties && file.properties.type;
-
-	// A converted doc will either be processing,
-	// or present with the d2l-converted-doc class
-	if (file && file.getLinkByClass('d2l-converted-doc')) {
-		mimeType = file.getLinkByClass('d2l-converted-doc').type;
-	} else if (fileActivity.getSubEntityByClass('processing')) {
-		return D2LSequencesContentRouter.fileProcessing;
-	}
-
-	return D2LSequencesContentRouter.mimeType.get(mimeType) || D2LSequencesContentRouter.fileUnknown;
-}
-
-function getLinkEntityType(linkActivity) {
-	const link = linkActivity.getLinkByRel('about');
-	const embedLink = linkActivity.getLinkByClass('embed');
-	const openInNewTab = linkActivity.hasClass('open-in-new-tab');
-	const isLorPdf = link.hasClass('adapted-lor-pdf');
-	if (link && isLorPdf) {
-		return D2LSequencesContentFilePdf.is;
-	} else if (
-		(link && link.href.startsWith(window.location.protocol)) ||
-		(embedLink && embedLink.href.startsWith(window.location.protocol))
-	) {
-		return openInNewTab ? D2LSequencesContentLinkNewTab.is : D2LSequencesContentLink.is;
-	} else {
-		return D2LSequencesContentLinkMixed.is;
-	}
-}
 

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -98,7 +98,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					inexplicably subtracting 12px from the height of the iframe,
 					and fixing that offset here will prevent a double scrollbar */
 					height: calc(100% + 12px);
-
 					box-sizing: border-box;
 					overflow: auto;
 					display: flex;
@@ -106,14 +105,15 @@ class D2LSequenceViewer extends mixinBehaviors([
 					padding: 18px 0;
 					flex-direction: column;
 				}
-
 				:host([is-not-html-entity]) #viewframe {
 					/*Viewframe max width is 1170px, but viewer has 30px
 					inherent padding horizontally to account for.*/
 					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
 					margin: 0 auto;
 				}
-
+				#viewframe:focus {
+					outline: none;
+				}
 				d2l-button-subtle {
 					margin: 0 0 12px var(--viewframe-horizontal-margin);
 					width: min-content;
@@ -123,10 +123,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 					display: inline-block;
 					height: 100%;
 					overflow-y: auto;
-					margin: 0 var(--viewframe-horizontal-margin);
 				}
-				#viewframe:focus {
-					outline: none;
+				:host([is-not-html-entity]) .viewer {
+					margin: 0 var(--viewframe-horizontal-margin);
 				}
 				.hide {
 					display: none;

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -18,7 +18,7 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { getEntityType } from '../components/d2l-sequences-content-router.js';
+import EntityTypeHelper from '../helpers/entity-type-helper.js';
 import TelemetryHelper from '../helpers/telemetry-helper.js';
 import PerformanceHelper from '../helpers/performance-helper.js';
 import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
@@ -426,7 +426,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 
 	async _onEntityChanged(entity) {
 		this._showDocReaderContent = false;
-		this.isNotHtmlEntity = getEntityType(entity) !== D2LSequencesContentFileHtml.is;
+		this.isNotHtmlEntity = EntityTypeHelper.getEntityType(entity) !== D2LSequencesContentFileHtml.is;
 
 		//entity is null or not first time loading the page
 		if (!entity || this._loaded) {

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -39,7 +39,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 		<custom-style include="d2l-typography">
 			<style is="custom-style" include="d2l-typography">
 				:host {
-					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
 					--sidebar-absolute-width: 80%;
 					--sidebar-min-width: 280px;
@@ -96,15 +95,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 					inexplicably subtracting 12px from the height of the iframe,
 					and fixing that offset here will prevent a double scrollbar */
 					height: calc(100% + 12px);
-					/*Viewframe max width is 1170px, but viewer has 30px
-					inherent padding horizontally to account for.*/
-					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
 
 					box-sizing: border-box;
 					overflow: auto;
 					display: flex;
 					flex: 2;
-					margin: 0 auto;
 					padding: 18px 0;
 					flex-direction: column;
 				}

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -18,8 +18,10 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { getEntityType } from '../components/d2l-sequences-content-router.js';
 import TelemetryHelper from '../helpers/telemetry-helper.js';
 import PerformanceHelper from '../helpers/performance-helper.js';
+import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
 
 /*
 * @polymer
@@ -39,6 +41,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		<custom-style include="d2l-typography">
 			<style is="custom-style" include="d2l-typography">
 				:host {
+					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
 					--sidebar-absolute-width: 80%;
 					--sidebar-min-width: 280px;
@@ -103,6 +106,14 @@ class D2LSequenceViewer extends mixinBehaviors([
 					padding: 18px 0;
 					flex-direction: column;
 				}
+
+				:host([is-not-html-entity]) #viewframe {
+					/*Viewframe max width is 1170px, but viewer has 30px
+					inherent padding horizontally to account for.*/
+					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
+					margin: 0 auto;
+				}
+
 				d2l-button-subtle {
 					margin: 0 0 12px var(--viewframe-horizontal-margin);
 					width: min-content;
@@ -362,6 +373,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 			_docReaderText: {
 				type: String,
 				value: '',
+			},
+			isNotHtmlEntity: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: true,
 			}
 		};
 	}
@@ -411,6 +427,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 
 	async _onEntityChanged(entity) {
 		this._showDocReaderContent = false;
+		this.isNotHtmlEntity = getEntityType(entity) !== D2LSequencesContentFileHtml.is;
 
 		//entity is null or not first time loading the page
 		if (!entity || this._loaded) {

--- a/helpers/entity-type-helper.js
+++ b/helpers/entity-type-helper.js
@@ -1,0 +1,126 @@
+import { D2LSequencesContentEoLMain } from '../components/d2l-sequences-content-eol-main.js';
+import '../components/d2l-sequences-content-file-download.js';
+import { D2LSequencesContentFileHtml } from '../components/d2l-sequences-content-file-html.js';
+import { D2LSequencesContentFilePdf } from '../components/d2l-sequences-content-file-pdf.js';
+import { D2LSequencesContentVideo } from '../components/d2l-sequences-content-video';
+import { D2LSequencesContentAudio } from '../components/d2l-sequences-content-audio';
+import { D2LSequencesContentImage } from '../components/d2l-sequences-content-image';
+import '../components/d2l-sequences-content-file-html.js';
+import { D2LSequencesContentLinkMixed } from '../components/d2l-sequences-content-link-mixed.js';
+import { D2LSequencesContentLinkNewTab } from '../components/d2l-sequences-content-link-new-tab';
+import { D2LSequencesContentLinkScorm } from '../components/d2l-sequences-content-link-scorm.js';
+import { D2LSequencesContentLinkOnedrive } from '../components/d2l-sequences-content-link-onedrive.js';
+import { D2LSequencesContentLinkGoogledrive } from '../components/d2l-sequences-content-link-googledrive.js';
+import { D2LSequencesContentLink } from '../components/d2l-sequences-content-link.js';
+import { D2LSequencesContentUnknown } from '../components/d2l-sequences-content-unknown.js';
+import { D2LSequencesContentFileProcessing } from '../components/d2l-sequences-content-file-processing';
+import { D2LSequencesContentModule } from '../components/d2l-sequences-content-module.js';
+import { D2LSequencesContentContentServiceLink } from '../components/d2l-sequences-content-content-service-link.js';
+import { D2LSequencesContentFileDownload } from '../components/d2l-sequences-content-file-download';
+
+class EntityTypeHelper {
+	static get fileActivity() {
+		return 'file-activity';
+	}
+	static get fileUnknown() {
+		return D2LSequencesContentFileDownload.is;
+	}
+	static get fileProcessing() {
+		return D2LSequencesContentFileProcessing.is;
+	}
+	static get linkActivity() {
+		return 'link-activity';
+	}
+	static get mimeType() {
+		return new Map([
+			['application/pdf', D2LSequencesContentFilePdf.is],
+			['video/mp4', D2LSequencesContentVideo.is],
+			['video/ogg', D2LSequencesContentVideo.is],
+			['video/webm', D2LSequencesContentVideo.is],
+			['audio/webm', D2LSequencesContentVideo.is],
+			['audio/flac', D2LSequencesContentAudio.is],
+			['audio/mp3', D2LSequencesContentAudio.is],
+			['audio/ogg', D2LSequencesContentAudio.is],
+			['audio/aac', D2LSequencesContentAudio.is],
+			['audio/wave', D2LSequencesContentAudio.is],
+			['image/bmp', D2LSequencesContentImage.is],
+			['image/gif', D2LSequencesContentImage.is],
+			['image/jpeg', D2LSequencesContentImage.is],
+			['image/png', D2LSequencesContentImage.is],
+			['image/svg+xml', D2LSequencesContentImage.is],
+			['text/html', D2LSequencesContentFileHtml.is]
+		]);
+	}
+
+	static getEntityType(entity) {
+		if (!entity || !entity.entities) {
+			return D2LSequencesContentUnknown.is;
+		}
+
+		if (entity.class.includes(D2LSequencesContentEoLMain.eolClass)) {
+			return D2LSequencesContentEoLMain.is;
+		}
+
+		if (entity.class.includes(D2LSequencesContentModule.contentModuleClass)) {
+			return D2LSequencesContentModule.is;
+		}
+
+		for (let i = 0; i < entity.entities.length; i++) {
+			const subEntity = entity.entities[i];
+			// hypermedia classes tend to be more specific at the end of the array
+			for (let j = subEntity.class.length - 1; j >= 0; --j) {
+				switch (subEntity.class[j]) {
+					case D2LSequencesContentLinkOnedrive.contentClass:
+						return D2LSequencesContentLinkOnedrive.is;
+					case D2LSequencesContentLinkGoogledrive.contentClass:
+						return D2LSequencesContentLinkGoogledrive.is;
+					case EntityTypeHelper.fileActivity:
+						return EntityTypeHelper.getFileEntityType(subEntity);
+					case EntityTypeHelper.linkActivity:
+						return EntityTypeHelper.getLinkEntityType(subEntity);
+					case D2LSequencesContentLinkScorm.contentClass:
+						return subEntity.hasClass('open-in-new-tab') ? D2LSequencesContentLinkScorm.is : D2LSequencesContentContentServiceLink.is;
+					case 'link-scorm-2004':
+						return D2LSequencesContentLinkScorm.is;
+					case 'link-scorm-1-2':
+						return D2LSequencesContentLinkScorm.is;
+				}
+			}
+		}
+		return D2LSequencesContentUnknown.is;
+	}
+
+	static  getFileEntityType(fileActivity) {
+		const file = fileActivity.getSubEntityByClass('file');
+		let mimeType = file && file.properties && file.properties.type;
+
+		// A converted doc will either be processing,
+		// or present with the d2l-converted-doc class
+		if (file && file.getLinkByClass('d2l-converted-doc')) {
+			mimeType = file.getLinkByClass('d2l-converted-doc').type;
+		} else if (fileActivity.getSubEntityByClass('processing')) {
+			return EntityTypeHelper.fileProcessing;
+		}
+
+		return EntityTypeHelper.mimeType.get(mimeType) || EntityTypeHelper.fileUnknown;
+	}
+
+	static getLinkEntityType(linkActivity) {
+		const link = linkActivity.getLinkByRel('about');
+		const embedLink = linkActivity.getLinkByClass('embed');
+		const openInNewTab = linkActivity.hasClass('open-in-new-tab');
+		const isLorPdf = link.hasClass('adapted-lor-pdf');
+		if (link && isLorPdf) {
+			return D2LSequencesContentFilePdf.is;
+		} else if (
+			(link && link.href.startsWith(window.location.protocol)) ||
+			(embedLink && embedLink.href.startsWith(window.location.protocol))
+		) {
+			return openInNewTab ? D2LSequencesContentLinkNewTab.is : D2LSequencesContentLink.is;
+		} else {
+			return D2LSequencesContentLinkMixed.is;
+		}
+	}
+}
+
+export default EntityTypeHelper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,0 +1,2 @@
+export const VIEWER_MAX_WIDTH = 1170;
+export const VIEWER_HORIZONTAL_MARGIN = 30;


### PR DESCRIPTION
Adjusted sequence viewer styles so that HTML activities had the scroll bar on the far right. Had to inject CSS styles on `<body>` tag in `<iframe>` since that is where the scroll bar lives. Should be a relatively safe change since all html content will be injected in the `<body>` tag and I assume this won't change over time. Attached below are screenshots with the new scroll bar and visuals on what the injected styles look like. Open to suggestions for improvements or if you think this change is worth it.

Since our team does not own other activities like discussions, assignments, checklists, etc. it is difficult to manipulate the DOM styling similarly to the HTML component since their DOM structure could change without us knowing causing any changes to break in the future. 

![html-without-nav](https://user-images.githubusercontent.com/64804046/91193456-1bf1d200-e6c5-11ea-9996-483c89cd1d06.PNG)
![html-with-nav](https://user-images.githubusercontent.com/64804046/91193469-1eecc280-e6c5-11ea-881d-1d24c22d8266.PNG)


