### PR TITLE
Prevent contentDocument error and style accordingly

### DIFF
--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -69,11 +69,16 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 	}
 
 	_setIframeStyles() {
+		// If parent domain does not match fileLocation domain, contentDocument will return null
+		// and log an error in the console. Code is wrapped in if-statement to clean up console errors
+		// and prevent unnecessary errors
 		const htmlIframe = this.$.content;
 		const maxWidth = VIEWER_MAX_WIDTH + (2 * VIEWER_HORIZONTAL_MARGIN);
-		htmlIframe.contentDocument.body.style.maxWidth = `${maxWidth}px`;
-		htmlIframe.contentDocument.body.style.margin = '0 auto';
-		htmlIframe.contentDocument.body.style.padding = `0 ${VIEWER_HORIZONTAL_MARGIN}px`;
+		if (htmlIframe && htmlIframe.contentDocument && htmlIframe.contentDocument.body) {
+			htmlIframe.contentDocument.body.style.maxWidth = `${maxWidth}px`;
+			htmlIframe.contentDocument.body.style.margin = '0 auto';
+			htmlIframe.contentDocument.body.style.padding = `0 ${VIEWER_HORIZONTAL_MARGIN}px`;
+		}
 	}
 
 	_scrollToTop() {

--- a/components/d2l-sequences-content-file-html.js
+++ b/components/d2l-sequences-content-file-html.js
@@ -1,10 +1,26 @@
 import '../mixins/d2l-sequences-automatic-completion-tracking-mixin.js';
 import { VIEWER_MAX_WIDTH, VIEWER_HORIZONTAL_MARGIN } from '../util/constants';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+const MAX_WIDTH = VIEWER_MAX_WIDTH + (2 * VIEWER_HORIZONTAL_MARGIN);
+
 export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.AutomaticCompletionTrackingMixin() {
 	static get template() {
 		return html`
 			<style>
+				:host {
+					--viewer-max-width: 1170px;
+					--viewframe-horizontal-margin: 30px;
+				}
+				:host([back-up-styles]) iframe {
+					margin: 0 auto;
+					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
+				}
+				:host([back-up-styles]) .d2l-sequences-content-container {
+					display: flex;
+					justify-content: center;
+					margin: 0 var(--viewframe-horizontal-margin);
+				}
 				.d2l-sequences-content-container {
 					-webkit-overflow-scrolling: touch;
 					overflow-y: auto;
@@ -41,6 +57,11 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 				notify: true,
 				observer: '_scrollToTop'
 			},
+			backUpStyles: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
 			_fileLocation: {
 				type: String,
 				computed: '_getFileLocation(entity)'
@@ -69,15 +90,16 @@ export class D2LSequencesContentFileHtml extends D2L.Polymer.Mixins.Sequences.Au
 	}
 
 	_setIframeStyles() {
-		// If parent domain does not match fileLocation domain, contentDocument will return null
-		// and log an error in the console. Code is wrapped in if-statement to clean up console errors
-		// and prevent unnecessary errors
 		const htmlIframe = this.$.content;
-		const maxWidth = VIEWER_MAX_WIDTH + (2 * VIEWER_HORIZONTAL_MARGIN);
 		if (htmlIframe && htmlIframe.contentDocument && htmlIframe.contentDocument.body) {
-			htmlIframe.contentDocument.body.style.maxWidth = `${maxWidth}px`;
+			htmlIframe.contentDocument.body.style.maxWidth = `${MAX_WIDTH}px`;
 			htmlIframe.contentDocument.body.style.margin = '0 auto';
 			htmlIframe.contentDocument.body.style.padding = `0 ${VIEWER_HORIZONTAL_MARGIN}px`;
+		} else {
+			// If parent domain does not match fileLocation domain, contentDocument will return null
+			// and we cannot properly style the iframe. This backup allows us to style the html doc
+			// but without the scroll bar pushed to the right.
+			this.backUpStyles = true;
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.13",
+  "version": "2.2.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When the parent and iframe domain are different, `contentDocument` returns `null` and we can't properly style the contents of the iframe. To prevent a JavaScript error when `contentDocument` is `null` we only style the iframe when we know `contentDocument` (and related properties) exist. 

To ensure that we style the html document consistently regardless of the existence of `contentDocument` I have added back-up styles. These back-up styles ensure the proper width and margin are set on the iframe while sacrificing the ability to have the scroll bar on the far right. Without these back-up styles the html document would take up the full width of the screen and lack consistency with the other activity styles in LX.

**Desired styles** (domains match and we can style the iframe with the scroll bar on the far right): 
![scroll-bar-right](https://user-images.githubusercontent.com/64804046/93215645-b083a900-f734-11ea-8d96-da4de30e7aa3.PNG)

**Back-up styles** (see that the scroll bar is directly beside the html content):
![scroll-bar](https://user-images.githubusercontent.com/64804046/93215717-cbeeb400-f734-11ea-81da-532b3f0277f5.PNG)

