### PR TITLE
DE39481 - Added mirrored styling for rtl

### DIFF
--- a/components/d2l-sequences-content-link-new-tab.js
+++ b/components/d2l-sequences-content-link-new-tab.js
@@ -11,6 +11,9 @@ export class D2LSequencesContentLinkNewTab extends D2L.Polymer.Mixins.Sequences.
 	static get template() {
 		return html`
 		<style>
+			:host {
+				--svg-center-offset: 60px;
+			}
 			.content-link-new-tab-container {
 				padding-top: 100px;
 				text-align: center;
@@ -27,12 +30,12 @@ export class D2LSequencesContentLinkNewTab extends D2L.Polymer.Mixins.Sequences.
 			}
 
 			#linkImage {
-				margin-left: 60px;
+				margin-left: var(--svg-center-offset);
 			}
 
 			:host(:dir(rtl)) #linkImage {
 				margin-left: initial;
-				margin-right: 60px;
+				margin-right: var(--svg-center-offset);
 				-webkit-transform: scale(-1, 1);
 				transform: scale(-1, 1);
 				transform-origin: center;

--- a/components/d2l-sequences-content-link-new-tab.js
+++ b/components/d2l-sequences-content-link-new-tab.js
@@ -26,13 +26,21 @@ export class D2LSequencesContentLinkNewTab extends D2L.Polymer.Mixins.Sequences.
 				color: var(--d2l-color-celestine-plus-1);
 			}
 
-			#linkImage{
-				margin-left:60px;
+			#linkImage {
+				margin-left: 60px;
+			}
+
+			:host(:dir(rtl)) #linkImage {
+				margin-left: initial;
+				margin-right: 60px;
+				-webkit-transform: scale(-1, 1);
+				transform: scale(-1, 1);
+				transform-origin: center;
 			}
 
 		</style>
 		<div class="content-link-new-tab-container">
-			<svg id= "linkImage" xmlns="http://www.w3.org/2000/svg" width="252" height="200" viewBox="0 0 252 200">
+			<svg id="linkImage" xmlns="http://www.w3.org/2000/svg" width="252" height="200" viewBox="0 0 252 200">
 				<g fill="none" fill-rule="evenodd" transform="translate(-1180 -98)">
 					<circle cx="1280" cy="198" r="100" fill="#E8F2F9"/>
 					<g fill-rule="nonzero">

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -17,6 +17,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		<style>
 			:host {
 				--d2l-icon-padding: 15px;
+				--title-container-padding: 5px;
 				display: block;
 				@apply --d2l-body-compact-text;
 			}
@@ -90,12 +91,12 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				display: inline-flex;
 				align-items: center;
 				word-break: break-all;
-				padding-right: 5px;
+				padding-right: var(--title-container-padding);
 				width: 90%;
 			}
 			:host(:dir(rtl)) #title-container {
 				padding-right: initial;
-				padding-left: 5px;
+				padding-left: var(--title-container-padding);
 			}
 
 			d2l-icon,

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -93,6 +93,10 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				padding-right: 5px;
 				width: 90%;
 			}
+			:host(:dir(rtl)) #title-container {
+				padding-right: initial;
+				padding-left: 5px;
+			}
 
 			d2l-icon,
 			a,
@@ -135,6 +139,10 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				padding-right: var(--d2l-left-icon-padding);
 				color: var(--d2l-color-celestine);
 				min-width: 18px;
+			}
+			:host(:dir(rtl)) d2l-icon {
+				padding-right: 0;
+				padding-left: var(--d2l-left-icon-padding);
 			}
 
 			d2l-completion-status {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -16,7 +16,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		return html`
 		<style>
 			:host {
-				--d2l-left-icon-padding: 15px;
+				--d2l-icon-padding: 15px;
 				display: block;
 				@apply --d2l-body-compact-text;
 			}
@@ -136,13 +136,13 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			}
 
 			d2l-icon {
-				padding-right: var(--d2l-left-icon-padding);
+				padding-right: var(--d2l-icon-padding);
 				color: var(--d2l-color-celestine);
 				min-width: 18px;
 			}
 			:host(:dir(rtl)) d2l-icon {
-				padding-right: 0;
-				padding-left: var(--d2l-left-icon-padding);
+				padding-right: initial;
+				padding-left: var(--d2l-icon-padding);
 			}
 
 			d2l-completion-status {

--- a/d2l-sequence-navigator/d2l-eol-activity-link.js
+++ b/d2l-sequence-navigator/d2l-eol-activity-link.js
@@ -106,6 +106,9 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 					var(--d2l-icon-size)
 				);
 			}
+			:host(:dir(rtl)) .d2l-activity-link-title {
+				text-align: right;
+			}
 
 			a {
 				@apply --d2l-body-compact-text;
@@ -128,6 +131,10 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 				padding-top: 3px;
 				padding-right: var(--d2l-left-icon-padding);
 				color: var(--d2l-activity-link-text-color);
+			}
+			:host(:dir(rtl)) d2l-icon {
+				padding-right: initial;
+				padding-left: var(--d2l-left-icon-padding);
 			}
 
 			:host([inner-last]) {

--- a/d2l-sequence-navigator/d2l-eol-activity-link.js
+++ b/d2l-sequence-navigator/d2l-eol-activity-link.js
@@ -19,7 +19,7 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 				--d2l-activity-link-text-color: var(--d2l-color-ferrite);
 				--d2l-activity-link-opacity: 1;
 				--d2l-activity-link-backdrop-opacity: 0;
-				--d2l-left-icon-padding: 15px;
+				--d2l-icon-padding: 15px;
 				--d2l-icon-size: 18px;
 				display: block;
 				cursor: pointer;
@@ -102,7 +102,7 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 				word-wrap: break-word;
 				width: calc(
 					100% -
-					var(--d2l-left-icon-padding) -
+					var(--d2l-icon-padding) -
 					var(--d2l-icon-size)
 				);
 			}
@@ -129,12 +129,12 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 
 			d2l-icon {
 				padding-top: 3px;
-				padding-right: var(--d2l-left-icon-padding);
+				padding-right: var(--d2l-icon-padding);
 				color: var(--d2l-activity-link-text-color);
 			}
 			:host(:dir(rtl)) d2l-icon {
 				padding-right: initial;
-				padding-left: var(--d2l-left-icon-padding);
+				padding-left: var(--d2l-icon-padding);
 			}
 
 			:host([inner-last]) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -25,6 +25,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-meter-size: 48px;
+			--module-completion-count-padding: 3px;
 			width: calc(100% - 20px);
 			height: calc(100% - 18px);
 			background-color: var(--d2l-lesson-header-background-color);
@@ -56,12 +57,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			color: var(--d2l-lesson-header-text-color);
 			text-align: right;
 			padding-top: 10px;
-			padding-right: 3px;
+			padding-right: var(--module-completion-count-padding);
 		}
 
 		:host(:dir(rtl)) .module-completion-count {
 			padding-right: initial;
-			padding-left: 3px;
+			padding-left: var(--module-completion-count-padding);
 			text-align: left;
 		}
 

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -59,6 +59,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			padding-right: 3px;
 		}
 
+		:host(:dir(rtl)) .module-completion-count {
+			padding-right: initial;
+			padding-left: 3px;
+			text-align: left;
+		}
+
 		.d2l-header-lesson-link,
 		.d2l-header-lesson-link:hover {
 			cursor: pointer;

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -144,6 +144,11 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				padding-left: 10px;
 			}
 
+			:host(:dir(rtl)) #expand-icon {
+				padding-left: initial;
+				padding-right: 10px;
+			}
+
 			@keyframes loadingShimmer {
 				0% { background-color: var(--d2l-color-sylvite); }
 				50% { background-color: var(--d2l-color-regolith); }

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -22,6 +22,7 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				display: block;
 				@apply --d2l-body-compact-text;
 				--d2l-outer-module-text-color: var(--d2l-color-ferrite);
+				--expand-icon-padding: 10px;
 			}
 
 			d2l-labs-accordion-collapse {
@@ -141,12 +142,12 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			}
 
 			#expand-icon {
-				padding-left: 10px;
+				padding-left: var(--expand-icon-padding);
 			}
 
 			:host(:dir(rtl)) #expand-icon {
 				padding-left: initial;
-				padding-right: 10px;
+				padding-right: var(--expand-icon-padding);
 			}
 
 			@keyframes loadingShimmer {

--- a/d2l-sequence-navigator/d2l-sequence-end.js
+++ b/d2l-sequence-navigator/d2l-sequence-end.js
@@ -18,6 +18,9 @@ class D2LSequenceEnd extends ASVFocusWithinMixin(
 					position: relative;
 					margin: 6px 0;
 				}
+				:host(:dir(rtl)) #d2l-sequence-end-container {
+					padding: 20px 20px 20px 40px;
+				}
 
 				#d2l-sequence-end-container.d2l-asv-current {
 					background-color: var(--d2l-color-gypsum);

--- a/d2l-sequence-navigator/d2l-sequence-end.js
+++ b/d2l-sequence-navigator/d2l-sequence-end.js
@@ -11,15 +11,18 @@ class D2LSequenceEnd extends ASVFocusWithinMixin(
 	static get template() {
 		return html`
 			<style>
+				:host {
+					--d2l-sequence-end-container-padding: 40px;
+				}
 				#d2l-sequence-end-container {
 					color: var(--d2l-color-ferrite);
 					border-radius: 6px;
-					padding: 20px 40px 20px 20px;
+					padding: 20px var(--d2l-sequence-end-container-padding) 20px 20px;
 					position: relative;
 					margin: 6px 0;
 				}
 				:host(:dir(rtl)) #d2l-sequence-end-container {
-					padding: 20px 20px 20px 40px;
+					padding: 20px 20px 20px var(--d2l-sequence-end-container-padding);
 				}
 
 				#d2l-sequence-end-container.d2l-asv-current {

--- a/d2l-sequence-viewer/d2l-sequence-viewer-header.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer-header.js
@@ -35,11 +35,6 @@ PolymerElement) {
 				display: flex;
 				flex: 1;
 			}
-			:host([is-sidebar-closed]) #header-left-inner {
-				max-width: 260px;
-				border-right: none;
-				box-shadow: none;
-			}
 			#header-left-inner {
 				display: flex;
 				flex: 1;
@@ -53,6 +48,15 @@ PolymerElement) {
 				-o-transition: max-width 0.4s ease-in-out;
 				transition: max-width 0.4s ease-in-out;
 			}
+			:host(:dir(rtl)) #header-left-inner {
+				border-right: none;
+				border-left: 1px solid #00000029;
+			}
+			:host([is-sidebar-closed]) #header-left-inner {
+				max-width: 260px;
+				border: none;
+				box-shadow: none;
+			}
 			#header-right {
 				display: flex;
 				flex: 1;
@@ -65,10 +69,20 @@ PolymerElement) {
 			#header-right d2l-sequence-viewer-iterator.next-button {
 				padding-right: 24px;
 			}
+			:host(:dir(rtl)) #header-right d2l-sequence-viewer-iterator.next-button {
+				padding-right: initial;
+				padding-left: 24px;
+			}
 			.back-to-module {
 				@apply --d2l-body-small-text;
 				padding-left: 24px;
 				margin-left: 0;
+			}
+			:host(:dir(rtl)) .back-to-module {
+				padding-left: initial;;
+				padding-right: 24px;
+				margin-left: initial;
+				margin-right: 0;
 			}
 			.flyout-menu {
 				display: flex;
@@ -76,8 +90,15 @@ PolymerElement) {
 				align-items: center;
 				margin-left: auto;
 			}
+			:host(:dir(rtl)) .flyout-menu {
+				margin-left: initial;
+				margin-right: auto;
+			}
 			.d2l-flyout-menu {
 				padding: 0 24px 0 15px;
+			}
+			:host(:dir(rtl)) .d2l-flyout-menu {
+				padding: 0 15px 0 24px;
 			}
 			.topic-name {
 				@apply --d2l-body-compact-text;

--- a/d2l-sequence-viewer/d2l-sequence-viewer-header.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer-header.js
@@ -26,6 +26,12 @@ PolymerElement) {
 	static get template() {
 		return html`
 		<style>
+			:host {
+				--header-inner-border: 1px solid #00000029;
+				--d2l-sequence-viewer-button-padding: 24px;
+				--d2l-flyout-menu-right-padding: 24px;
+				--d2l-flyout-menu-left-padding: 15px;
+			}
 			#container {
 				display: flex;
 				align-items: center;
@@ -41,7 +47,7 @@ PolymerElement) {
 				z-index: 2;
 				background: white;
 				max-width: 570px;
-				border-right: 1px solid #00000029;
+				border-right: var(--header-inner-border);
 				box-shadow: 2px 0 12px #00000029;
 				-webkit-transition: max-width 0.4s ease-in-out;
 				-moz-transition: max-width 0.4s ease-in-out;
@@ -50,7 +56,7 @@ PolymerElement) {
 			}
 			:host(:dir(rtl)) #header-left-inner {
 				border-right: none;
-				border-left: 1px solid #00000029;
+				border-left: var(--header-inner-border);
 			}
 			:host([is-sidebar-closed]) #header-left-inner {
 				max-width: 260px;
@@ -67,20 +73,20 @@ PolymerElement) {
 				padding: 0 24px;
 			}
 			#header-right d2l-sequence-viewer-iterator.next-button {
-				padding-right: 24px;
+				padding-right: var(--d2l-sequence-viewer-button-padding);
 			}
 			:host(:dir(rtl)) #header-right d2l-sequence-viewer-iterator.next-button {
 				padding-right: initial;
-				padding-left: 24px;
+				padding-left: var(--d2l-sequence-viewer-button-padding);
 			}
 			.back-to-module {
 				@apply --d2l-body-small-text;
-				padding-left: 24px;
+				padding-left: var(--d2l-sequence-viewer-button-padding);
 				margin-left: 0;
 			}
 			:host(:dir(rtl)) .back-to-module {
 				padding-left: initial;;
-				padding-right: 24px;
+				padding-right: var(--d2l-sequence-viewer-button-padding);
 				margin-left: initial;
 				margin-right: 0;
 			}
@@ -95,10 +101,10 @@ PolymerElement) {
 				margin-right: auto;
 			}
 			.d2l-flyout-menu {
-				padding: 0 24px 0 15px;
+				padding: 0 var(--d2l-flyout-menu-right-padding) 0 var(--d2l-flyout-menu-left-padding);
 			}
 			:host(:dir(rtl)) .d2l-flyout-menu {
-				padding: 0 15px 0 24px;
+				padding: 0 var(--d2l-flyout-menu-left-padding) 0 var(--d2l-flyout-menu-right-padding);
 			}
 			.topic-name {
 				@apply --d2l-body-compact-text;

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -191,6 +191,14 @@ class D2LSequenceViewer extends mixinBehaviors([
 						-o-transition: left 0.4s ease-in-out;
 						transition: left 0.4s ease-in-out;
 					}
+					:host(:dir(rtl)) #sidebar-container {
+						left: auto;
+						right: 0;
+						-webkit-transition: right 0.4s ease-in-out;
+						-moz-transition: right 0.4s ease-in-out;
+						-o-transition: right 0.4s ease-in-out;
+						transition: right 0.4s ease-in-out;
+					}
 					#sidebar-container.offscreen {
 						max-width: var(--sidebar-max-width);
 						left: calc(-1 * var(--sidebar-max-width));
@@ -198,6 +206,14 @@ class D2LSequenceViewer extends mixinBehaviors([
 						-moz-transition: left 0.4s ease-in-out;
 						-o-transition: left 0.4s ease-in-out;
 						transition: left 0.4s ease-in-out;
+					}
+					:host(:dir(rtl)) #sidebar-container.offscreen {
+						left: auto;
+						right: calc(-1 * var(--sidebar-max-width));
+						-webkit-transition: right 0.4s ease-in-out;
+						-moz-transition: right 0.4s ease-in-out;
+						-o-transition: right 0.4s ease-in-out;
+						transition: right 0.4s ease-in-out;
 					}
 				}
 			</style>


### PR DESCRIPTION
This PR addresses [this defect](https://rally1.rallydev.com/#/detail/defect/397757644020) by adding styling for RTL languages. It is in conjunction with [this PR](https://github.com/BrightspaceUI/core/pull/890), which deals with the circular progress bar and the previous/next arrow icons.

This PR makes CSS changes to:

- Header element spacing and behavior ('Back to Content' moving, 'X', ellipsis)
- Mobile sidebar flyout direction
- Sidebar spacing (icons, arrows, completion count (old progress bar))
- End of unit page (icons and labels)

Down the road, it would be nice to use [logical properties ](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) so that we don't have to constantly change styling between left/right. However, we'll have to wait until it is more widely supported.