### PR TITLE
Added property for enabling media downloads

### DIFF
--- a/components/d2l-sequences-content-audio.js
+++ b/components/d2l-sequences-content-audio.js
@@ -15,7 +15,7 @@ export class D2LSequencesContentAudio extends D2L.Polymer.Mixins.Sequences.Autom
 			}
 		</style>
 		<template is="dom-if" if="[[useMediaPlayer]]">
-			<d2l-labs-media-player src="[[_fileLocation]]"></d2l-labs-media-player>
+			<d2l-labs-media-player src="[[_fileLocation]]" allow-download="[[allowMediaDownloads]]"></d2l-labs-media-player>
 		</template>
 		<template is="dom-if" if="[[!useMediaPlayer]]">
 			<d2l-audio src="[[_fileLocation]]" auto-load=""></d2l-audio>
@@ -43,6 +43,11 @@ export class D2LSequencesContentAudio extends D2L.Polymer.Mixins.Sequences.Autom
 				computed: '_getTitle(entity)'
 			},
 			useMediaPlayer: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
+			allowMediaDownloads: {
 				type: Boolean,
 				reflectToAttribute: true,
 				value: false

--- a/components/d2l-sequences-content-video.js
+++ b/components/d2l-sequences-content-video.js
@@ -15,7 +15,7 @@ export class D2LSequencesContentVideo extends D2L.Polymer.Mixins.Sequences.Autom
 			}
 		</style>
 		<template is="dom-if" if="[[useMediaPlayer]]">
-			<d2l-labs-media-player src="[[_fileLocation]]"></d2l-labs-media-player>
+			<d2l-labs-media-player src="[[_fileLocation]]" allow-download="[[allowMediaDownloads]]"></d2l-labs-media-player>
 		</template>
 		<template is="dom-if" if="[[!useMediaPlayer]]">
 			<d2l-video src="[[_fileLocation]]" auto-load=""></d2l-video>
@@ -43,6 +43,11 @@ export class D2LSequencesContentVideo extends D2L.Polymer.Mixins.Sequences.Autom
 				computed: '_getTitle(entity)'
 			},
 			useMediaPlayer: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
+			allowMediaDownloads: {
 				type: Boolean,
 				reflectToAttribute: true,
 				value: false

--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -281,6 +281,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 						cs-redirect-path=[[csRedirectPath]]
 						no-redirect-query-param-string=[[noRedirectQueryParamString]]
 						use-media-player=[[useMediaPlayer]]
+						allow-media-downloads=[[allowMediaDownloads]]
 					>
 					</d2l-sequences-content-router>
 				</template>
@@ -396,6 +397,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 				value: true,
 			},
 			useMediaPlayer: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
+			allowMediaDownloads: {
 				type: Boolean,
 				reflectToAttribute: true,
 				value: false

--- a/demo/d2l-sequence-viewer/index.html
+++ b/demo/d2l-sequence-viewer/index.html
@@ -25,6 +25,7 @@
 		href="data/l1-m2-activity2.json"
 		token="token"
 		use-media-player="true"
+		allow-media-downloads="true"
 		_module-properties='{"moduleIndex":2,"numberOfSiblingModules":6,"title":"Testo Courso","useNewProgressBar":true}'
 	>
 	</d2l-sequence-viewer>

--- a/mixins/d2l-sequences-router-mixin.js
+++ b/mixins/d2l-sequences-router-mixin.js
@@ -40,6 +40,11 @@ function RouterMixin(getEntityType) {
 					type: Boolean,
 					reflectToAttribute: true,
 					value: false
+				},
+				allowMediaDownloads: {
+					type: Boolean,
+					reflectToAttribute: true,
+					value: false
 				}
 			};
 		}
@@ -106,6 +111,7 @@ function RouterMixin(getEntityType) {
 						this._contentElement.csRedirectPath = this.csRedirectPath;
 						this._contentElement.noRedirectQueryParamString = this.noRedirectQueryParamString;
 						this._contentElement.useMediaPlayer = this.useMediaPlayer;
+						this._contentElement.allowMediaDownloads = this.allowMediaDownloads;
 					}
 				}
 			);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -139,16 +139,16 @@
       }
     },
     "@brightspace-ui-labs/media-player": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/media-player/-/media-player-1.9.0.tgz",
-      "integrity": "sha512-4ceLxVKa/ObHe8dhu+65nG1NHDOcac+JFgbpHkxcShmEA8ylyh3tOzNfl6YwZM5AN0tUN3bTtt9nOr+VMbI4Ug==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/media-player/-/media-player-1.16.0.tgz",
+      "integrity": "sha512-rzE+GeinPs8HUXLNe7gupki3/CQwJcLfJZh0CoQj83DFkdiE53rPIa9mHRfvo1bnAObm9si1VYpt5ASq3OvUuQ==",
       "requires": {
         "@brightspace-ui/core": "^1",
         "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
         "@webcomponents/webcomponentsjs": "^2",
         "lit-element": "^2",
         "parse-srt": "^1.0.0-alpha",
-        "resize-observer-polyfill": "^1.5.1"
+        "resize-observer-polyfill": "^1"
       }
     },
     "@brightspace-ui/core": {


### PR DESCRIPTION
`<d2l-labs-media-player>` now has a property `allow-download` with obvious meaning. This PR adds a property to the sequence viewer which is forwarded to the media player.

See related PR https://github.com/Brightspace/lms/pull/3027