### PR TITLE
DE39488: Adding html-block to module description to render MathML

### DIFF
--- a/components/d2l-sequences-content-module.js
+++ b/components/d2l-sequences-content-module.js
@@ -1,4 +1,5 @@
 import './d2l-sequences-module-name.js';
+import '@brightspace-ui/core/components/html-block/html-block.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -32,9 +33,10 @@ export class D2LSequencesContentModule extends mixinBehaviors([
 				<d2l-sequences-module-name href="[[href]]" token="[[token]]"></d2l-sequences-module-name>
 			</h1>
 
-			<p id="description">
-				[[description]]
-			</p>
+			<d2l-html-block>
+				<template id="description">
+				</template>
+			</d2l-html-block>
 		</div>
 `;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequences",
-  "version": "2.2.20",
+  "version": "2.2.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -152,15 +152,16 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.57.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.57.3.tgz",
-      "integrity": "sha512-g4RgYUH2OdZCl4vHOnf0Gqno6g+OgCnIHUDRemYD7qhkGNEItSX9xHT5LWDwINZwOpVXQC7bEBzwvY3Lt9j0hw==",
+      "version": "1.97.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.97.1.tgz",
+      "integrity": "sha512-vBBRr/Tn1lUtee/HXZFz9h5qqLc/niarQJ/Sev36eOe1EOx6+KURypQX1WUO6rAgMegYtKcdZJdXjuXtT717Fw==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
         "@open-wc/dedupe-mixin": "^1.2.17",
         "@webcomponents/shadycss": "^1",
         "@webcomponents/webcomponentsjs": "^2",
+        "focus-visible": "^5",
         "intl-messageformat": "^7",
         "lit-element": "^2",
         "prismjs": "^1",
@@ -221,11 +222,18 @@
       }
     },
     "@formatjs/intl-pluralrules": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.8.tgz",
-      "integrity": "sha512-OtL/rgKSSGljpxk2lRUC92ZqmzZjabwXO5zbBh2Bj8OM+z4U3H1Q5iK+ZY4k7a6EAoY7hWCr3F4k7EL8tcnQow==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
+      "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
       "requires": {
-        "@formatjs/intl-utils": "^2.2.5"
+        "@formatjs/intl-utils": "^2.3.0"
+      },
+      "dependencies": {
+        "@formatjs/intl-utils": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
+          "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
+        }
       }
     },
     "@formatjs/intl-unified-numberformat": {
@@ -268,9 +276,9 @@
       }
     },
     "@open-wc/dedupe-mixin": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.2.17.tgz",
-      "integrity": "sha512-9A3WohqNxEloJa4y1DuBL5zH12cNRNW1vsrkiaLMnOGuQdhibs2XY1oliudsKpvIeNjDXRVRPUdIIzn65BypCw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz",
+      "integrity": "sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw=="
     },
     "@polymer/app-layout": {
       "version": "3.1.0",
@@ -3391,6 +3399,11 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -6010,9 +6023,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
     },
@@ -11490,6 +11503,7 @@
           "requires": {
             "concat-stream": "1.6.2",
             "debug": "2.6.9",
+            "mkdirp": "0.5.1",
             "yauzl": "2.4.1"
           },
           "dependencies": {
@@ -14886,9 +14900,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mixin-deep": {
           "version": "1.3.2",
@@ -14923,17 +14937,17 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
@@ -14951,6 +14965,7 @@
             "growl": "1.10.5",
             "he": "1.1.1",
             "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
             "supports-color": "5.4.0"
           },
           "dependencies": {
@@ -17012,9 +17027,9 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+              "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
               "dev": true
             }
           }


### PR DESCRIPTION
This PR addresses [this defect](https://rally1.rallydev.com/#/detail/defect/397788029136). User-defined math equations do not render in module descriptions for Chrome and Edge. This is because the language used to generate the equations (MathML) is not supported by chromium browsers.

This PR wraps the module descriptions with a new web-component ([html-block](https://github.com/BrightspaceUI/core/tree/master/components/html-block)) which displays html and integrates MathJax, a library used for rendering MathML.

[Before](https://user-images.githubusercontent.com/52549862/97949963-ea4b5600-1d5a-11eb-8a3a-c759c511742c.png) and [after](https://user-images.githubusercontent.com/52549862/97950048-35656900-1d5b-11eb-8cb6-8928fa0ed20e.png).