### PR TITLE
Adjust style of d2l-labs-media-player

### DIFF
--- a/components/d2l-sequences-content-audio.js
+++ b/components/d2l-sequences-content-audio.js
@@ -8,7 +8,7 @@ export class D2LSequencesContentAudio extends D2L.Polymer.Mixins.Sequences.Autom
 	static get template() {
 		return html`
 		<style>
-			d2l-audio, d2l-labs-media-player {
+			d2l-audio {
 				width: 100%;
 				height: calc(100% - 12px);
 				overflow: hidden;

--- a/components/d2l-sequences-content-video.js
+++ b/components/d2l-sequences-content-video.js
@@ -8,7 +8,7 @@ export class D2LSequencesContentVideo extends D2L.Polymer.Mixins.Sequences.Autom
 	static get template() {
 		return html`
 		<style>
-			d2l-video, d2l-labs-media-player {
+			d2l-video {
 				width: 100%;
 				max-height: calc(100% - 12px);
 				overflow: hidden;


### PR DESCRIPTION
 Hiding overflow causes issues on mobile in landscape mode. Styles applied to d2l-video are not needed by labs media player.

<img width="1076" alt="Screen Shot 2020-11-11 at 2 55 40 PM" src="https://user-images.githubusercontent.com/22655/98858530-c5c43d80-242e-11eb-9b50-7ee286723f3d.png">

Removing the overflow hide allows the page to be scrolled.