### PR TITLE
use "npm ci" since this repo uses a lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Lint
         run: npm run lint
       - name: Unit Tests (SauceLabs)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Unit Tests (Headless)
         run: npm run test
       - name: Incremental Release


### PR DESCRIPTION
This repo uses a `package-lock` file, so `npm install` not only installs versions of dependencies it may not have been expecting, but it also modifies the lock file locally. This results in local `git` changes when doing a release, causing the `npm version` from the `release-incremental` action to fail.