### PR TITLE
Fix date container styles so tooltip is aligned properly on mobile

### DIFF
--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -174,9 +174,6 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				#due-date-time {
 					width: 100%;
 				}
-				#availability-dates {
-					width: fit-content;
-				}
 			}
 
 			@keyframes loadingShimmer {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -169,9 +169,13 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			@media (max-width: 525px) {
 				#date-container {
 					flex-direction: column;
+					align-items: flex-end;
+				}
+				#due-date-time {
+					width: 100%;
 				}
 				#availability-dates {
-					text-align: end;
+					width: fit-content;
 				}
 			}
 

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -108,9 +108,13 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			@media (max-width: 460px) {
 				#date-container {
 					flex-direction: column;
+					align-items: flex-end;
+				}
+				#due-date-time {
+					width: 100%;
 				}
 				#availability-dates {
-					text-align: end;
+					width: fit-content;
 				}
 			}
 

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -113,9 +113,6 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				#due-date-time {
 					width: 100%;
 				}
-				#availability-dates {
-					width: fit-content;
-				}
 			}
 
 			ol {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -208,9 +208,13 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		@media (max-width: 415px) {
 			div.date-container {
 				flex-direction: column;
+				align-items: flex-end;
+			}
+			#due-date-time {
+				width: 100%;
 			}
 			#availability-dates {
-				text-align: end;
+				width: fit-content;
 			}
 		}
 		</style>

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -213,9 +213,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			#due-date-time {
 				width: 100%;
 			}
-			#availability-dates {
-				width: fit-content;
-			}
 		}
 		</style>
 

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -136,9 +136,6 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				#due-date-time {
 					width: 100%;
 				}
-				#availability-dates {
-					width: fit-content;
-				}
 			}
 
 			:host([show-loading-skeleton]) .date-container {

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -131,9 +131,13 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			@media (max-width: 430px) {
 				div.date-container {
 					flex-direction: column;
+					align-items: flex-end;
+				}
+				#due-date-time {
+					width: 100%;
 				}
 				#availability-dates {
-					text-align: end;
+					width: fit-content;
 				}
 			}
 


### PR DESCRIPTION
### Issue
Availability dates container takes the whole width of the container. Tooltip is centered on this container, that's why it appears off.

Rally ticket: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F462167278952

![tooltip-LX-issue](https://user-images.githubusercontent.com/64804046/101376836-19d00f80-387f-11eb-86cb-43c4fda3aa56.PNG)

![tooltip-LX-issue-2](https://user-images.githubusercontent.com/64804046/101376980-4ab04480-387f-11eb-9725-ddb482584f05.PNG)

![tooltip-LX-broken](https://user-images.githubusercontent.com/64804046/101377039-57cd3380-387f-11eb-8d56-36539fd033fc.gif)

### Fix
Adjust the width of the availability dates container to fit its content and then right-justify it.
**Note:** the tooltip only appears on the left of the availability dates in mobile. Have yet to confirm with Tara on if this is okay. If this needs to be fixed the boundary of the tooltip will have to be adjusted in a follow up PR.

![tooltip-LX-style-fixed](https://user-images.githubusercontent.com/64804046/101377202-8814d200-387f-11eb-940d-bd3041c5daab.gif)

![tooltip-LX-fixed](https://user-images.githubusercontent.com/64804046/101377208-8a772c00-387f-11eb-9545-9f2851b2ac1f.gif)

