### PR TITLE
Availability date tool tip behaviour not consistent on iOS

### DIFF
--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -233,6 +233,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
 							title$="[[_availabilityDateAriaLabel]]"
+							onClick="[[_onDatesClick]]"
 						>
 							[[_availabilityDateString]]
 						</div>
@@ -387,6 +388,12 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return;
 		}
 		return getDueDateTimeString(properties.dueDate, this.localize);
+	}
+
+	// Prevent navigating/collapsing the background element when
+	// attempting to touch the dates for viewing the tooltip.
+	_onDatesClick(e) {
+		e.stopPropagation();
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -168,7 +168,6 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
-				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 525px) {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -240,7 +240,6 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-							close-on-click="true"
 						>
 							[[_availabilityDateTooltip]]
 						</d2l-tooltip>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -240,9 +240,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-						>
-							[[_availabilityDateTooltip]]
-						</d2l-tooltip>
+						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>
 			</template>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -409,9 +409,9 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate, dueDate } = properties;
+		const { startDate, endDate } = properties;
 
-		return startDate || endDate || dueDate;
+		return startDate || endDate;
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -240,7 +240,10 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-						>[[_availabilityDateTooltip]]</d2l-tooltip>
+							close-on-click="true"
+						>
+							[[_availabilityDateTooltip]]
+						</d2l-tooltip>
 					</div>
 				</div>
 			</template>
@@ -317,7 +320,12 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				type: String,
 				value: '',
 				computed: '_getAvailabilityDateAriaLabel(entity.properties)'
-			}
+			},
+			_showDates: {
+				type: Boolean,
+				value: false,
+				computed: '_getShowDates(entity.properties)'
+			},
 		};
 	}
 	static get observers() {
@@ -394,6 +402,16 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	// attempting to touch the dates for viewing the tooltip.
 	_onDatesClick(e) {
 		e.stopPropagation();
+	}
+
+	_getShowDates(properties) {
+		if (!properties) {
+			return false;
+		}
+
+		const { startDate, endDate, dueDate } = properties;
+
+		return startDate || endDate || dueDate;
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -240,6 +240,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
+							close-on-click="true" <!-- testing, keep if works -->
 						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -233,14 +233,13 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
 							title$="[[_availabilityDateAriaLabel]]"
-							onClick="[[_onDatesClick]]"
+							on-click="_onDatesClick"
 						>
 							[[_availabilityDateString]]
 						</div>
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-							close-on-click="true" <!-- testing, keep if works -->
 						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>

--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -168,6 +168,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
+				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 525px) {
@@ -229,7 +230,7 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<div id="due-date-time">[[_dueDateTimeString]]</div>
 						<div
 							id="availability-dates"
-							tabindex$="[[_getTabIndex(_showDates)]]"
+							tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
 							title$="[[_availabilityDateAriaLabel]]"
@@ -406,9 +407,9 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate } = properties;
+		const { startDate, endDate, dueDate } = properties;
 
-		return startDate || endDate;
+		return !!(startDate || endDate || dueDate);
 	}
 
 	_getAvailabilityDateString(properties) {
@@ -435,8 +436,8 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		return formatAvailabilityDateString(this.localize, startDate, endDate, availDateAriaLabelSuffix);
 	}
 
-	_getTabIndex(showDates) {
-		return showDates ? '0' : '-1';
+	_getTabIndex(showDates, availabilityDateString) {
+		return showDates && availabilityDateString.length ? '0' : '-1';
 	}
 }
 customElements.define(D2LActivityLink.is, D2LActivityLink);

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -107,7 +107,6 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
-				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 460px) {

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -184,6 +184,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 					role="note"
 					aria-label$="[[_availabilityDateAriaLabel]]"
 					title$="[[_availabilityDateAriaLabel]]"
+					on-click="[[_onDatesClick]]"
 				>
 					[[_availabilityDateString]]
 				</div>
@@ -402,6 +403,12 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return;
 		}
 		return getDueDateTimeString(properties.dueDate, this.localize);
+	}
+
+	// Prevent navigating/collapsing the background element when
+	// attempting to touch the dates for viewing the tooltip.
+	_onDatesClick(e) {
+		e.stopPropagation();
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -191,6 +191,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				<d2l-tooltip
 					for="availability-dates"
 					boundary="[[_availDateTooltipBoundary]]"
+					close-on-click="true" <!-- testing, keep if works -->
 				>[[_availabilityDateTooltip]]</d2l-tooltip>
 			</div>
 		</div>

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -191,9 +191,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				<d2l-tooltip
 					for="availability-dates"
 					boundary="[[_availDateTooltipBoundary]]"
-				>
-					[[_availabilityDateTooltip]]
-				</d2l-tooltip>
+				>[[_availabilityDateTooltip]]</d2l-tooltip>
 			</div>
 		</div>
 		<ol>

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -191,7 +191,6 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				<d2l-tooltip
 					for="availability-dates"
 					boundary="[[_availDateTooltipBoundary]]"
-					close-on-click="true"
 				>
 					[[_availabilityDateTooltip]]
 				</d2l-tooltip>

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -424,9 +424,9 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate, dueDate } = properties;
+		const { startDate, endDate } = properties;
 
-		return !!(startDate || endDate || dueDate);
+		return !!(startDate || endDate);
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -107,6 +107,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
+				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 460px) {
@@ -180,7 +181,7 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				<div id="due-date-time">[[_dueDateTimeString]]</div>
 				<div
 					id="availability-dates"
-					tabindex$="[[_getTabIndex(_showDates)]]"
+					tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 					role="note"
 					aria-label$="[[_availabilityDateAriaLabel]]"
 					title$="[[_availabilityDateAriaLabel]]"
@@ -421,9 +422,9 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate } = properties;
+		const { startDate, endDate, dueDate } = properties;
 
-		return !!(startDate || endDate);
+		return !!(startDate || endDate || dueDate);
 	}
 
 	_getAvailabilityDateString(properties) {
@@ -450,8 +451,8 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		return formatAvailabilityDateString(this.localize, startDate, endDate, availDateAriaLabelSuffix);
 	}
 
-	_getTabIndex(showDates) {
-		return showDates ? '0' : '-1';
+	_getTabIndex(showDates, availabilityDateString) {
+		return showDates && availabilityDateString.length ? '0' : '-1';
 	}
 }
 customElements.define(D2LInnerModule.is, D2LInnerModule);

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -191,7 +191,10 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				<d2l-tooltip
 					for="availability-dates"
 					boundary="[[_availDateTooltipBoundary]]"
-				>[[_availabilityDateTooltip]]</d2l-tooltip>
+					close-on-click="true"
+				>
+					[[_availabilityDateTooltip]]
+				</d2l-tooltip>
 			</div>
 		</div>
 		<ol>
@@ -289,7 +292,12 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				type: String,
 				value: '',
 				computed: '_getAvailabilityDateAriaLabel(entity.properties)'
-			}
+			},
+			_showDates: {
+				type: Boolean,
+				value: false,
+				computed: '_getShowDates(entity.properties)'
+			},
 		};
 	}
 
@@ -409,6 +417,16 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	// attempting to touch the dates for viewing the tooltip.
 	_onDatesClick(e) {
 		e.stopPropagation();
+	}
+
+	_getShowDates(properties) {
+		if (!properties) {
+			return false;
+		}
+
+		const { startDate, endDate, dueDate } = properties;
+
+		return !!(startDate || endDate || dueDate);
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -184,14 +184,13 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 					role="note"
 					aria-label$="[[_availabilityDateAriaLabel]]"
 					title$="[[_availabilityDateAriaLabel]]"
-					on-click="[[_onDatesClick]]"
+					on-click="_onDatesClick"
 				>
 					[[_availabilityDateString]]
 				</div>
 				<d2l-tooltip
 					for="availability-dates"
 					boundary="[[_availDateTooltipBoundary]]"
-					close-on-click="true" <!-- testing, keep if works -->
 				>[[_availabilityDateTooltip]]</d2l-tooltip>
 			</div>
 		</div>

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -452,9 +452,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate, dueDate } = properties;
+		const { startDate, endDate } = properties;
 
-		return startDate || endDate || dueDate;
+		return startDate || endDate;
 	}
 
 	_getDueDateTimeString(properties) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -257,7 +257,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 					</div>
 					<d2l-tooltip
 						for="availability-dates"
-						close-on-click="true"
 					>
 						[[_availabilityDateTooltip]]
 					</d2l-tooltip>

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -255,7 +255,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 					>
 						[[_availabilityDateString]]
 					</div>
-					<d2l-tooltip for="availability-dates">[[_availabilityDateTooltip]]</d2l-tooltip>
+					<d2l-tooltip for="availability-dates">[[_availabilityDateTooltip]] close-on-click="true" <!-- testing, keep if works -->
+					</d2l-tooltip>
 				</div>
 			</div>
 			<template is="dom-if" if="[[!_useNewProgressBar]]">

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -207,7 +207,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 		#due-date-time, #availability-dates {
 			font-size: 0.65rem;
-			line-height: var(--d2l-body-small-text_-_line-height);
 		}
 
 		@media (max-width: 415px) {

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -257,9 +257,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 					</div>
 					<d2l-tooltip
 						for="availability-dates"
-					>
-						[[_availabilityDateTooltip]]
-					</d2l-tooltip>
+					>[[_availabilityDateTooltip]]</d2l-tooltip>
 				</div>
 			</div>
 			<template is="dom-if" if="[[!_useNewProgressBar]]">

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -255,7 +255,11 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 					>
 						[[_availabilityDateString]]
 					</div>
-					<d2l-tooltip for="availability-dates">[[_availabilityDateTooltip]] close-on-click="true" <!-- testing, keep if works -->
+					<d2l-tooltip
+						for="availability-dates"
+						close-on-click="true"
+					>
+						[[_availabilityDateTooltip]]
 					</d2l-tooltip>
 				</div>
 			</div>

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -207,6 +207,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 		#due-date-time, #availability-dates {
 			font-size: 0.65rem;
+			line-height: var(--d2l-body-small-text_-_line-height);
 		}
 
 		@media (max-width: 415px) {
@@ -247,7 +248,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 					<div id="due-date-time">[[_dueDateTimeString]]</div>
 					<div
 						id="availability-dates"
-						tabindex$="[[_getTabIndex(_showDates)]]"
+						tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 						role="note"
 						aria-label$="[[_availabilityDateAriaLabel]]"
 						title$="[[_availabilityDateAriaLabel]]"
@@ -449,9 +450,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate } = properties;
+		const { startDate, endDate, dueDate } = properties;
 
-		return startDate || endDate;
+		return startDate || endDate || dueDate;
 	}
 
 	_getDueDateTimeString(properties) {
@@ -500,10 +501,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		return classes.join(' ');
 	}
 
-	_getTabIndex(showDates) {
-		return showDates ? '0' : '-1';
+	_getTabIndex(showDates, availabilityDateString) {
+		return showDates && availabilityDateString.length ? '0' : '-1';
 	}
-
 }
 
 window.customElements.define(D2LLessonHeader.is, D2LLessonHeader);

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -251,6 +251,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 						role="note"
 						aria-label$="[[_availabilityDateAriaLabel]]"
 						title$="[[_availabilityDateAriaLabel]]"
+						on-click="_onDatesClick"
 					>
 						[[_availabilityDateString]]
 					</div>
@@ -456,6 +457,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			return;
 		}
 		return getDueDateTimeString(properties.dueDate, this.localize);
+	}
+
+	// Prevent navigating/collapsing the background element when
+	// attempting to touch the dates for viewing the tooltip.
+	_onDatesClick(e) {
+		e.stopPropagation();
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -321,7 +321,10 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-						>[[_availabilityDateTooltip]]</d2l-tooltip>
+							close-on-click="true"
+						>
+							[[_availabilityDateTooltip]]
+						</d2l-tooltip>
 					</div>
 				</div>
 			</div>
@@ -498,7 +501,12 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 				type: Boolean,
 				reflectToAttribute: true,
 				computed: '_checkModuleHeaderActive(currentActivity, entity, _hideModuleDescription)'
-			}
+			},
+			_showDates: {
+				type: Boolean,
+				value: false,
+				computed: '_getShowDates(entity.properties)'
+			},
 		};
 	}
 
@@ -679,6 +687,16 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 	// attempting to touch the dates for viewing the tooltip.
 	_onDatesClick(e) {
 		e.stopPropagation();
+	}
+
+	_getShowDates(properties) {
+		if (!properties) {
+			return false;
+		}
+
+		const { startDate, endDate, dueDate } = properties;
+
+		return !!(startDate || endDate || dueDate);
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -130,7 +130,6 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
-				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 430px) {

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -130,6 +130,7 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			#due-date-time, #availability-dates {
 				color: var(--d2l-color-ferrite);
 				font-size: 0.65rem;
+				line-height: var(--d2l-body-small-text_-_line-height);
 			}
 
 			@media (max-width: 430px) {
@@ -310,7 +311,7 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<div id="due-date-time">[[_dueDateTimeString]]</div>
 						<div
 							id="availability-dates"
-							tabindex$="[[_getTabIndex(_showDates)]]"
+							tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
 							title$="[[_availabilityDateAriaLabel]]"
@@ -691,9 +692,9 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate } = properties;
+		const { startDate, endDate, dueDate } = properties;
 
-		return !!(startDate || endDate);
+		return !!(startDate || endDate || dueDate);
 	}
 
 	_getAvailabilityDateString(properties) {
@@ -822,8 +823,8 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 		}
 	}
 
-	_getTabIndex(showDates) {
-		return showDates ? '0' : '-1';
+	_getTabIndex(showDates, availabilityDateString) {
+		return showDates && availabilityDateString.length ? '0' : '-1';
 	}
 }
 customElements.define(D2LOuterModule.is, D2LOuterModule);

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -694,9 +694,9 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return false;
 		}
 
-		const { startDate, endDate, dueDate } = properties;
+		const { startDate, endDate } = properties;
 
-		return !!(startDate || endDate || dueDate);
+		return !!(startDate || endDate);
 	}
 
 	_getAvailabilityDateString(properties) {

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -321,9 +321,7 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-						>
-							[[_availabilityDateTooltip]]
-						</d2l-tooltip>
+						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>
 			</div>

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -321,7 +321,6 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-<!--							close-on-click="true" &lt;!&ndash; testing, keep if works &ndash;&gt;-->
 						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -321,7 +321,6 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-							close-on-click="true"
 						>
 							[[_availabilityDateTooltip]]
 						</d2l-tooltip>

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -321,7 +321,7 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
-							close-on-click="true" <!-- testing, keep if works -->
+<!--							close-on-click="true" &lt;!&ndash; testing, keep if works &ndash;&gt;-->
 						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -314,12 +314,14 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
 							title$="[[_availabilityDateAriaLabel]]"
+							on-click="_onDatesClick"
 						>
 							[[_availabilityDateString]]
 						</div>
 						<d2l-tooltip
 							for="availability-dates"
 							boundary="[[_availDateTooltipBoundary]]"
+							close-on-click="true" <!-- testing, keep if works -->
 						>[[_availabilityDateTooltip]]</d2l-tooltip>
 					</div>
 				</div>
@@ -672,6 +674,12 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 			return;
 		}
 		return getDueDateTimeString(properties.dueDate, this.localize);
+	}
+
+	// Prevent navigating/collapsing the background element when
+	// attempting to touch the dates for viewing the tooltip.
+	_onDatesClick(e) {
+		e.stopPropagation();
 	}
 
 	_getAvailabilityDateString(properties) {


### PR DESCRIPTION
There were a few problems with the tooltip in LX that this pr will fix:

1. On mobile, tapping on the avail dates to make the tooltip show was difficult as the tap area was very small.
2. Even if you tapped directly in the middle, the tap would go behind the date and perform the action of the element behind it. This could be expanding/collapsing, or even navigating into LX.
3. Tabbing to the avail dates (not mobile) was broken.