### PR TITLE
Removing title properties from availability dates

### DIFF
--- a/d2l-sequence-navigator/d2l-activity-link.js
+++ b/d2l-sequence-navigator/d2l-activity-link.js
@@ -233,7 +233,6 @@ class D2LActivityLink extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 							tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
-							title$="[[_availabilityDateAriaLabel]]"
 							on-click="_onDatesClick"
 						>
 							[[_availabilityDateString]]

--- a/d2l-sequence-navigator/d2l-inner-module.js
+++ b/d2l-sequence-navigator/d2l-inner-module.js
@@ -184,7 +184,6 @@ class D2LInnerModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 					tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 					role="note"
 					aria-label$="[[_availabilityDateAriaLabel]]"
-					title$="[[_availabilityDateAriaLabel]]"
 					on-click="_onDatesClick"
 				>
 					[[_availabilityDateString]]

--- a/d2l-sequence-navigator/d2l-lesson-header.js
+++ b/d2l-sequence-navigator/d2l-lesson-header.js
@@ -251,7 +251,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 						tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 						role="note"
 						aria-label$="[[_availabilityDateAriaLabel]]"
-						title$="[[_availabilityDateAriaLabel]]"
 						on-click="_onDatesClick"
 					>
 						[[_availabilityDateString]]

--- a/d2l-sequence-navigator/d2l-outer-module.js
+++ b/d2l-sequence-navigator/d2l-outer-module.js
@@ -314,7 +314,6 @@ class D2LOuterModule extends PolymerASVLaunchMixin(CompletionStatusMixin()) {
 							tabindex$="[[_getTabIndex(_showDates, _availabilityDateString)]]"
 							role="note"
 							aria-label$="[[_availabilityDateAriaLabel]]"
-							title$="[[_availabilityDateAriaLabel]]"
 							on-click="_onDatesClick"
 						>
 							[[_availabilityDateString]]

--- a/test/d2l-sequence-navigator/d2l-activity-link.html
+++ b/test/d2l-sequence-navigator/d2l-activity-link.html
@@ -182,9 +182,6 @@ describe('d2l-activity-link', () => {
 				expect(availDateText.getAttribute('aria-label'))
 					.to
 					.equal('Starts October 29. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Starts October 29. Read full date and time.');
 			});
 		});
 
@@ -210,9 +207,6 @@ describe('d2l-activity-link', () => {
 				expect(availDateText.getAttribute('aria-label'))
 					.to
 					.equal('Ends October 31. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Ends October 31. Read full date and time.');
 			});
 		});
 
@@ -236,9 +230,6 @@ describe('d2l-activity-link', () => {
 			it('should render correct availability aria-label and title', () => {
 				const availDateText = element.shadowRoot.querySelector('#availability-dates');
 				expect(availDateText.getAttribute('aria-label'))
-					.to
-					.equal('October 20 - November 11. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
 					.to
 					.equal('October 20 - November 11. Read full date and time.');
 			});

--- a/test/d2l-sequence-navigator/d2l-inner-module.html
+++ b/test/d2l-sequence-navigator/d2l-inner-module.html
@@ -252,10 +252,7 @@ describe('d2l-inner-module', () => {
 				const availDateText = element.shadowRoot.querySelector('#availability-dates');
 				expect(availDateText.getAttribute('aria-label'))
 					.to
-					.equal('Starts October 29. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Starts October 29. Read full date and time.');
+					.equal('Starts October 29. Read full date and time.')
 			});
 		});
 
@@ -281,9 +278,6 @@ describe('d2l-inner-module', () => {
 				expect(availDateText.getAttribute('aria-label'))
 					.to
 					.equal('Ends October 31. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Ends October 31. Read full date and time.');
 			});
 		});
 
@@ -307,9 +301,6 @@ describe('d2l-inner-module', () => {
 			it('should render correct availability aria-label and title', () => {
 				const availDateText = element.shadowRoot.querySelector('#availability-dates');
 				expect(availDateText.getAttribute('aria-label'))
-					.to
-					.equal('October 20 - November 11. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
 					.to
 					.equal('October 20 - November 11. Read full date and time.');
 			});

--- a/test/d2l-sequence-navigator/d2l-inner-module.html
+++ b/test/d2l-sequence-navigator/d2l-inner-module.html
@@ -252,7 +252,7 @@ describe('d2l-inner-module', () => {
 				const availDateText = element.shadowRoot.querySelector('#availability-dates');
 				expect(availDateText.getAttribute('aria-label'))
 					.to
-					.equal('Starts October 29. Read full date and time.')
+					.equal('Starts October 29. Read full date and time.');
 			});
 		});
 

--- a/test/d2l-sequence-navigator/d2l-lesson-header.html
+++ b/test/d2l-sequence-navigator/d2l-lesson-header.html
@@ -253,9 +253,6 @@ describe('d2l-lesson-header', () => {
 					expect(availDateText.getAttribute('aria-label'))
 						.to
 						.equal('Starts October 29. Read full date and time.');
-					expect(availDateText.getAttribute('title'))
-						.to
-						.equal('Starts October 29. Read full date and time.');
 				});
 			});
 
@@ -281,9 +278,6 @@ describe('d2l-lesson-header', () => {
 					expect(availDateText.getAttribute('aria-label'))
 						.to
 						.equal('Ends October 31. Read full date and time.');
-					expect(availDateText.getAttribute('title'))
-						.to
-						.equal('Ends October 31. Read full date and time.');
 				});
 			});
 
@@ -307,9 +301,6 @@ describe('d2l-lesson-header', () => {
 				it('should render correct availability aria-label and title', () => {
 					const availDateText = element.shadowRoot.querySelector('#availability-dates');
 					expect(availDateText.getAttribute('aria-label'))
-						.to
-						.equal('October 20 - November 11. Read full date and time.');
-					expect(availDateText.getAttribute('title'))
 						.to
 						.equal('October 20 - November 11. Read full date and time.');
 				});

--- a/test/d2l-sequence-navigator/d2l-outer-module.html
+++ b/test/d2l-sequence-navigator/d2l-outer-module.html
@@ -449,9 +449,6 @@ describe('d2l-outer-module', () => {
 				expect(availDateText.getAttribute('aria-label'))
 					.to
 					.equal('Starts October 29. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Starts October 29. Read full date and time.');
 			});
 		});
 
@@ -477,9 +474,6 @@ describe('d2l-outer-module', () => {
 				expect(availDateText.getAttribute('aria-label'))
 					.to
 					.equal('Ends October 31. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
-					.to
-					.equal('Ends October 31. Read full date and time.');
 			});
 		});
 
@@ -503,9 +497,6 @@ describe('d2l-outer-module', () => {
 			it('should render correct availability aria-label and title', () => {
 				const availDateText = element.shadowRoot.querySelector('#availability-dates');
 				expect(availDateText.getAttribute('aria-label'))
-					.to
-					.equal('October 20 - November 11. Read full date and time.');
-				expect(availDateText.getAttribute('title'))
 					.to
 					.equal('October 20 - November 11. Read full date and time.');
 			});


### PR DESCRIPTION
This was causing some ugly UX, and was redundant with the existing tooltip text on availability dates