### PR TITLE
DE43897 - fixing Back to Content button completion tracking

### DIFF
--- a/d2l-sequence-viewer/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer.js
@@ -580,6 +580,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 
 	_onClickBack() {
 		this.telemetryClient.logTelemetryEvent('back-to-content');
+		this.dispatchEvent(new CustomEvent('back-to-content', { bubbles: true, composed: true }));
 
 		if (!this.backToContentLink) {
 			return;

--- a/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-automatic-completion-tracking-mixin.js
@@ -28,7 +28,8 @@ function AutomaticCompletionTrackingMixin() {
 
 		ready() {
 			super.ready();
-			this._finishCompletionCallback = this.finishCompletion.bind(this);
+			this._finishCompletionCallback = this.getFinishCompletionHandler().bind(this);
+			this._immediateFinishCompletionCallback = this.getFinishCompletionHandler({ delay: 0 }).bind(this);
 			this._visibilityChangeCallback = function() {
 				if (document.visibilityState === 'hidden') {
 					this._finishCompletionCallback();
@@ -43,6 +44,7 @@ function AutomaticCompletionTrackingMixin() {
 			window.addEventListener('pagehide', this._finishCompletionCallback);
 			window.addEventListener('visibilitychange', this._visibilityChangeCallback);
 			window.addEventListener('beforeunload', this._finishCompletionCallback);
+			window.addEventListener('back-to-content', this._immediateFinishCompletionCallback);
 		}
 
 		disconnectedCallback() {
@@ -51,6 +53,7 @@ function AutomaticCompletionTrackingMixin() {
 			window.removeEventListener('pagehide', this._finishCompletionCallback);
 			window.removeEventListener('visibilitychange', this._visibilityChangeCallback);
 			window.removeEventListener('beforeunload', this._finishCompletionCallback);
+			window.removeEventListener('back-to-content', this._immediateFinishCompletionCallback);
 		}
 
 		_onHrefChanged(href, previousHref) {

--- a/mixins/d2l-sequences-completion-tracking-mixin.js
+++ b/mixins/d2l-sequences-completion-tracking-mixin.js
@@ -28,15 +28,21 @@ function CompletionTrackingMixin() {
 			};
 		}
 
+		getFinishCompletionHandler({ delay = FINISH_COMPLETION_DELAY } = {}) {
+			// we don't want any chance of a delay if delay was set to 0,
+			// see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
+			return delay > 0 ?
+				() => setTimeout(() => this.finishCompletion(), delay) :
+				() => this.finishCompletion();
+		}
+
 		finishCompletion() {
 			if (!this._completionEntity || this._skipCompletion) {
 				return;
 			}
 
-			setTimeout(() => {
-				this._performViewActions(this._completionEntity, 'finish-view-activity')
-					.then(() => { this._completionEntity = null; });
-			}, FINISH_COMPLETION_DELAY);
+			this._performViewActions(this._completionEntity, 'finish-view-activity')
+				.then(() => { this._completionEntity = null; });
 		}
 
 		startCompletion() {


### PR DESCRIPTION
## Relevant Rally Links

- [DE43897](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F601409434557&fdp=true?fdp=true): Lessons/New Learner experience/Content Statistics > 20.21.05 > Total Time Spent and Average Time Spent not calculating for users content topic visits



## Description

When the "Back to Content" button was clicked, the automatic completion tracking mixin wouldn't work due to the timeout around the completion tracking action being called. This timeout is necessary to allow for completion queues to clear.



## Goal/Solution

Here I'm reworking the automatic completion tracking mixin to allow for us to specify the timeout. Then, when the "Back to Content" button is clicked, a `back-to-content` event is fired and handled by immediately calling the completion tracking action.



## Video/Screenshots

Statistics before fix:
![before_back_to_content_fix](https://user-images.githubusercontent.com/64805612/122579831-4e3d3900-d023-11eb-8a8d-ca2e85a84f14.gif)

Statistics after fix:
![after_back_to_content_fix](https://user-images.githubusercontent.com/64805612/122579862-55fcdd80-d023-11eb-8df0-78d0f7cfec1a.gif)




## Related PRs

N/A



## Remaining Work
- [x] Dev Testing: another developer will test this code on their machine
- [ ] Fix completion tracking on back button in browser pressed before navigating around LX, see [DE44070](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F602131736115&fdp=true?fdp=true): Lessons/LX/Content Statistics > Total Time Spent and Average Time Spent not calculating for users content topic visits when browser back button pressed
