### PR TITLE
DE44103 - Latest met set entity needs to be null checked

### DIFF
--- a/d2l-sequence-viewer/d2l-sequence-viewer-new-content-alert.js
+++ b/d2l-sequence-viewer/d2l-sequence-viewer-new-content-alert.js
@@ -229,7 +229,11 @@ class D2LSequenceViewerNewContentAlert extends mixinBehaviors([
 		if (this.latestMetSetEndpoint) {
 			await window.D2L.Siren.EntityStore.fetch(this.latestMetSetEndpoint, this.token, true)
 				.then(({ entity }) => {
-					if (entity.properties.newConditionsSetsAreMet) {
+					if (!entity) {
+						return;
+					}
+
+					if (entity.properties && entity.properties.newConditionsSetsAreMet) {
 						const newContentEntities = entity.getSubEntitiesByRel('newly-released-object');
 						const newContent = newContentEntities
 							.map(content => {


### PR DESCRIPTION
## Relevant Rally Links

- [DE44103](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F602260789957&fdp=true?fdp=true): LX > Fix "Cannot read property 'properties' of null" JS error



## Description

On prod sites in LX, we get an error logged that states: `TypeError: Cannot read property 'properties' of null` at `async HTMLElement._fetchLatestReleasedContent`. The `LatestMetSetController` in the LMS never returns a null entity, but even if it did, the `d2l-polymer-siren-behaviors` always returns an object with the expected Siren entity properties, though those properties may be null. The Siren behaviors do store `null` in the entity store while waiting for the entity to load, but the function in LX waits for the entity store to finish fetching so this shouldn't affect it. I haven't been able to reproduce the issues locally or on quad sites, but it happens a lot on prod.

**Edit to update:**

When `d2l-polymer-siren-behaviors` has an error in the promise chain [here](https://github.com/Brightspace/polymer-siren-behaviors/blob/master/store/entity-store.js#L198), it returns an object with `entity: null` and `status: error`. LX doesn't handle this error and so tries to use the entity as if the call was successful.


## Goal/Solution

Verify that the `entity` object and `properties` property are not `null` or `undefined`. This fix should result in LX handling the `null` entity properly, but we could also add another potential improvement to log the fact that we received an error from the `fetch`.


## Video/Screenshots

N/A


## Related PRs

N/A


## Remaining Work

- [x] Dev Testing: another developer will test this code on their machine. Here since I don't know how to reproduce it, we should verify that we still get alerts that new content is available in LX.
